### PR TITLE
feat: dynamic contract registration for newly created Assets

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -32,15 +32,6 @@ networks:
         address:
           - "0x513972072Ae1985506e2FC3b3d9A46fe0F0eCDB5" 
       - name: Asset
-        # address:
-        #   - "0xca6f6d53ec05bbfd0a1888b777ea729549f66454"
-        #   - "0xcdd88d9f65a79de88b512dd72276620ea0641aad"
-        #   - "0xffb9bf5c3e811288c5b63acffaa8fd9a0f705227"
-        #   - "0xc01ca58aebdf0ae085b9f229dc4b25d4386e3504"
-        #   - "0x427a32acc5a1ebf3956df80d454c1184814170cf"
-        #   - "0x043887c55b378bead8cda17b1498fca5146f7e2e"
-        #   - "0x5b0c3f7c3bd95efdbf913c50be935c9ab969fcd1"
-        #   - "0x827a062637c52be85c3e7b79fd171d3ac21b9bad"
 
   # For local testing, see readme
   # - id: 31337 # Anvil local network

--- a/config.yaml
+++ b/config.yaml
@@ -32,15 +32,15 @@ networks:
         address:
           - "0x513972072Ae1985506e2FC3b3d9A46fe0F0eCDB5" 
       - name: Asset
-        address:
-          - "0xca6f6d53ec05bbfd0a1888b777ea729549f66454"
-          - "0xcdd88d9f65a79de88b512dd72276620ea0641aad"
-          - "0xffb9bf5c3e811288c5b63acffaa8fd9a0f705227"
-          - "0xc01ca58aebdf0ae085b9f229dc4b25d4386e3504"
-          - "0x427a32acc5a1ebf3956df80d454c1184814170cf"
-          - "0x043887c55b378bead8cda17b1498fca5146f7e2e"
-          - "0x5b0c3f7c3bd95efdbf913c50be935c9ab969fcd1"
-          - "0x827a062637c52be85c3e7b79fd171d3ac21b9bad"
+        # address:
+        #   - "0xca6f6d53ec05bbfd0a1888b777ea729549f66454"
+        #   - "0xcdd88d9f65a79de88b512dd72276620ea0641aad"
+        #   - "0xffb9bf5c3e811288c5b63acffaa8fd9a0f705227"
+        #   - "0xc01ca58aebdf0ae085b9f229dc4b25d4386e3504"
+        #   - "0x427a32acc5a1ebf3956df80d454c1184814170cf"
+        #   - "0x043887c55b378bead8cda17b1498fca5146f7e2e"
+        #   - "0x5b0c3f7c3bd95efdbf913c50be935c9ab969fcd1"
+        #   - "0x827a062637c52be85c3e7b79fd171d3ac21b9bad"
 
   # For local testing, see readme
   # - id: 31337 # Anvil local network

--- a/src/EventHandlers.ts
+++ b/src/EventHandlers.ts
@@ -61,7 +61,7 @@ AssetRegistry.AssetCreated.handler(async ({ event, context }) => {
 
 AssetRegistry.AssetCreated.contractRegister(async ({ event, context }) => {
   const assetAddress = event.params.asset.toLowerCase();
-  context.addAsset(assetAddress)
+  context.addAsset(assetAddress);
 });
 
 AssetRegistry.OwnershipTransferred.handler(async ({ event, context }) => {

--- a/src/EventHandlers.ts
+++ b/src/EventHandlers.ts
@@ -59,6 +59,11 @@ AssetRegistry.AssetCreated.handler(async ({ event, context }) => {
   context.AssetIdToAddress.set(mapping);
 });
 
+AssetRegistry.AssetCreated.contractRegister(async ({ event, context }) => {
+  const assetAddress = event.params.asset.toLowerCase();
+  context.addAsset(assetAddress)
+});
+
 AssetRegistry.OwnershipTransferred.handler(async ({ event, context }) => {
   const entity: AssetContract_OwnershipTransferred = {
     id: `${event.chainId}_${event.block.number}_${event.logIndex}`,


### PR DESCRIPTION
Closes #4 

**Important Note**: This change requires a full resync (wiping the DB) so the indexer re-processes the AssetRegistry history from block 10299077. As it replays the AssetCreated events for the existing contracts, it will dynamically register them and continue indexing without manual config updates.