### PR TITLE
feat(api): add custom GraphQL v2 endpoint at /v2/graphql

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,39 +115,43 @@ Grafana is available at `http://localhost:3000` (default credentials: `admin` / 
 
 ## API
 
-The indexer exposes two endpoints:
+The indexer exposes the following endpoints:
 
 | Endpoint | Description |
 |---|---|
-| `GET /` | GraphQL playground (browser UI) |
-| `POST /graphql` | GraphQL API |
+| `GET /` | Auto-generated GraphQL playground |
+| `POST /graphql` | Auto-generated GraphQL API (Ponder) |
+| `POST /v2/graphql` | Custom GraphQL API (recommended) |
 | `GET /ready` | Health check — returns `200` when live |
 
-### GraphQL
+### GraphQL v2 (recommended)
 
-Open the playground at `http://localhost:42069` after starting the indexer.
+The v2 endpoint at `/v2/graphql` is the recommended API. Open the GraphiQL playground at `http://localhost:42069/v2/graphql` after starting the indexer.
 
-Ponder generates a singular (fetch by ID) and plural (list) field for each table:
+**Key differences from the auto-generated endpoint:**
+- **Case-insensitive address filters** — pass addresses in any casing; the `Address` scalar normalises them automatically
+- **Equality-only filters** — simple `where` clauses with no `_gt`/`_lt`/`_in`/AND/OR operators
+- **List queries only** — no single-item-by-id queries
 
-| Singular | Plural | Description |
-|---|---|---|
-| `assetEntity` | `assetEntitys` | Asset contract state |
-| `subscription` | `subscriptions` | Subscription state per asset–subscriber |
-| `assetRegistry_AssetCreated` | `assetRegistry_AssetCreateds` | Asset creation events |
-| `assetRegistry_RegistryFeeShareUpdated` | `assetRegistry_RegistryFeeShareUpdateds` | Registry fee share updates |
-| `assetRegistry_RegistryFeeClaimedBatch` | `assetRegistry_RegistryFeeClaimedBatchs` | Registry fee claim batches |
-| `asset_SubscriptionAdded` | `asset_SubscriptionAddeds` | New subscription events |
-| `asset_SubscriptionExtended` | `asset_SubscriptionExtendeds` | Subscription extension events |
-| `asset_SubscriptionRevoked` | `asset_SubscriptionRevokeds` | Subscription revocation events |
-| `asset_SubscriptionCancelled` | `asset_SubscriptionCancelleds` | Subscription cancellation events |
-| `asset_SubscriptionPriceUpdated` | `asset_SubscriptionPriceUpdateds` | Price update events |
-| `asset_CreatorFeeClaimed` | `asset_CreatorFeeClaimeds` | Creator fee claim events |
-| `asset_OwnershipTransferred` | `asset_OwnershipTransferreds` | Asset ownership transfer events |
+#### Queries
 
-> **⚠️ Addresses are lowercased.** All address fields are stored in lowercase. Lowercase your address before querying:
-> ```ts
-> const address = walletAddress.toLowerCase();
-> ```
+| Query | Description |
+|---|---|
+| `registryEntitys` | Registry contract state |
+| `assetEntitys` | Asset contract state |
+| `subscriptions` | Subscription state per asset–subscriber |
+| `assetRegistry_AssetCreateds` | Asset creation events |
+| `assetRegistry_OwnershipTransferreds` | Registry ownership transfers |
+| `assetRegistry_RegistryFeeShareUpdateds` | Registry fee share updates |
+| `assetRegistry_RegistryFeeClaimedBatchs` | Registry fee claim batches |
+| `asset_SubscriptionAddeds` | New subscription events |
+| `asset_SubscriptionExtendeds` | Subscription extension events |
+| `asset_SubscriptionRevokeds` | Subscription revocation events |
+| `asset_SubscriptionCancelleds` | Subscription cancellation events |
+| `asset_SubscriptionPriceUpdateds` | Price update events |
+| `asset_CreatorFeeClaimeds` | Creator fee claim events |
+| `asset_OwnershipTransferreds` | Asset ownership transfer events |
+| `_meta` | Indexer sync status per chain |
 
 **Fetch all assets by owner:**
 ```graphql
@@ -163,16 +167,25 @@ Ponder generates a singular (fetch by ID) and plural (list) field for each table
 }
 ```
 
-**Check active subscriptions for a subscriber:**
+**Check subscriptions for a payer:**
 ```graphql
 {
-  subscriptions(where: { subscriber: "0x...", isActive: true }) {
+  subscriptions(where: { payer: "0x..." }) {
     items {
       assetId
+      subscriber
       startTime
       endTime
-      payer
     }
+  }
+}
+```
+
+**Check indexer sync status:**
+```graphql
+{
+  _meta {
+    status
   }
 }
 ```
@@ -180,20 +193,22 @@ Ponder generates a singular (fetch by ID) and plural (list) field for each table
 **Pagination:**
 ```graphql
 {
-  subscriptions(limit: 20, after: "cursor_from_previous_response") {
+  subscriptions(limit: 20, offset: 0) {
     items { ... }
     pageInfo {
       hasNextPage
-      endCursor
+      hasPreviousPage
     }
+    totalCount
   }
 }
 ```
 
 > **Notes:**
+> - Address filter fields accept any casing — `"0xAbCd..."` and `"0xabcd..."` both work
 > - All `BigInt` values are returned as strings to avoid JavaScript integer overflow
-> - All addresses are lowercase hex strings
 > - `blockTimestamp` is a Unix timestamp in seconds
+> - `subscriber` is a `bytes32` identity hash, not an address
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -119,8 +119,8 @@ The indexer exposes the following endpoints:
 
 | Endpoint | Description |
 |---|---|
-| `GET /` | Auto-generated GraphQL playground |
-| `POST /graphql` | Auto-generated GraphQL API (Ponder) |
+| `GET /` | Auto-generated GraphQL playground *(deprecated)* |
+| `POST /graphql` | Auto-generated GraphQL API (Ponder) *(deprecated — use `/v2/graphql`)* |
 | `POST /v2/graphql` | Custom GraphQL API (recommended) |
 | `GET /ready` | Health check — returns `200` when live |
 

--- a/package.json
+++ b/package.json
@@ -16,9 +16,11 @@
     "sync": "node scripts/sync-abis.js"
   },
   "dependencies": {
-    "ponder": "^0.16.6",
     "abitype": "^1.2.4",
+    "graphql": "^16.13.2",
+    "graphql-yoga": "^5.21.0",
     "hono": "^4.12.14",
+    "ponder": "^0.16.6",
     "viem": "^2.48.4"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,12 @@ importers:
       abitype:
         specifier: ^1.2.4
         version: 1.2.4(typescript@5.9.3)
+      graphql:
+        specifier: ^16.13.2
+        version: 16.13.2
+      graphql-yoga:
+        specifier: ^5.21.0
+        version: 5.21.0(graphql@16.13.2)
       hono:
         specifier: ^4.12.14
         version: 4.12.14
@@ -1094,8 +1100,14 @@ packages:
     peerDependencies:
       graphql: ^15.2.0 || ^16.0.0
 
-  graphql@16.13.1:
-    resolution: {integrity: sha512-gGgrVCoDKlIZ8fIqXBBb0pPKqDgki0Z/FSKNiQzSGj2uEYHr1tq5wmBegGwJx6QB5S5cM0khSBpi/JFHMCvsmQ==}
+  graphql-yoga@5.21.0:
+    resolution: {integrity: sha512-PS37UoDihx8209RRl1ogttzWevNYDnGvP7beHkwHzUpUdfZTHsVRTVe1ysGXre1EjwUAePbpez302YSrq70Ngw==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      graphql: ^15.2.0 || ^16.0.0
+
+  graphql@16.13.2:
+    resolution: {integrity: sha512-5bJ+nf/UCpAjHM8i06fl7eLyVC9iuNAjm9qzkiu2ZGhM0VscSvS6WDPfAwkdkBuoXGM9FJSbKl6wylMwP9Ktig==}
     engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
 
   graphql@16.8.2:
@@ -1906,28 +1918,28 @@ snapshots:
 
   '@escape.tech/graphql-armor-max-aliases@2.6.2':
     dependencies:
-      graphql: 16.13.1
+      graphql: 16.13.2
     optionalDependencies:
       '@envelop/core': 5.5.1
       '@escape.tech/graphql-armor-types': 0.7.0
 
   '@escape.tech/graphql-armor-max-depth@2.4.2':
     dependencies:
-      graphql: 16.13.1
+      graphql: 16.13.2
     optionalDependencies:
       '@envelop/core': 5.5.1
       '@escape.tech/graphql-armor-types': 0.7.0
 
   '@escape.tech/graphql-armor-max-tokens@2.5.1':
     dependencies:
-      graphql: 16.13.1
+      graphql: 16.13.2
     optionalDependencies:
       '@envelop/core': 5.5.1
       '@escape.tech/graphql-armor-types': 0.7.0
 
   '@escape.tech/graphql-armor-types@0.7.0':
     dependencies:
-      graphql: 16.13.1
+      graphql: 16.13.2
     optional: true
 
   '@eslint-community/eslint-utils@4.9.1(eslint@8.57.1)':
@@ -1955,6 +1967,16 @@ snapshots:
 
   '@fastify/busboy@3.2.0': {}
 
+  '@graphql-tools/executor@1.5.1(graphql@16.13.2)':
+    dependencies:
+      '@graphql-tools/utils': 11.0.0(graphql@16.13.2)
+      '@graphql-typed-document-node/core': 3.2.0(graphql@16.13.2)
+      '@repeaterjs/repeater': 3.0.6
+      '@whatwg-node/disposablestack': 0.0.6
+      '@whatwg-node/promise-helpers': 1.3.2
+      graphql: 16.13.2
+      tslib: 2.8.1
+
   '@graphql-tools/executor@1.5.1(graphql@16.8.2)':
     dependencies:
       '@graphql-tools/utils': 11.0.0(graphql@16.8.2)
@@ -1965,10 +1987,23 @@ snapshots:
       graphql: 16.8.2
       tslib: 2.8.1
 
+  '@graphql-tools/merge@9.1.7(graphql@16.13.2)':
+    dependencies:
+      '@graphql-tools/utils': 11.0.0(graphql@16.13.2)
+      graphql: 16.13.2
+      tslib: 2.8.1
+
   '@graphql-tools/merge@9.1.7(graphql@16.8.2)':
     dependencies:
       '@graphql-tools/utils': 11.0.0(graphql@16.8.2)
       graphql: 16.8.2
+      tslib: 2.8.1
+
+  '@graphql-tools/schema@10.0.31(graphql@16.13.2)':
+    dependencies:
+      '@graphql-tools/merge': 9.1.7(graphql@16.13.2)
+      '@graphql-tools/utils': 11.0.0(graphql@16.13.2)
+      graphql: 16.13.2
       tslib: 2.8.1
 
   '@graphql-tools/schema@10.0.31(graphql@16.8.2)':
@@ -1976,6 +2011,14 @@ snapshots:
       '@graphql-tools/merge': 9.1.7(graphql@16.8.2)
       '@graphql-tools/utils': 11.0.0(graphql@16.8.2)
       graphql: 16.8.2
+      tslib: 2.8.1
+
+  '@graphql-tools/utils@10.11.0(graphql@16.13.2)':
+    dependencies:
+      '@graphql-typed-document-node/core': 3.2.0(graphql@16.13.2)
+      '@whatwg-node/promise-helpers': 1.3.2
+      cross-inspect: 1.0.1
+      graphql: 16.13.2
       tslib: 2.8.1
 
   '@graphql-tools/utils@10.11.0(graphql@16.8.2)':
@@ -1986,6 +2029,14 @@ snapshots:
       graphql: 16.8.2
       tslib: 2.8.1
 
+  '@graphql-tools/utils@11.0.0(graphql@16.13.2)':
+    dependencies:
+      '@graphql-typed-document-node/core': 3.2.0(graphql@16.13.2)
+      '@whatwg-node/promise-helpers': 1.3.2
+      cross-inspect: 1.0.1
+      graphql: 16.13.2
+      tslib: 2.8.1
+
   '@graphql-tools/utils@11.0.0(graphql@16.8.2)':
     dependencies:
       '@graphql-typed-document-node/core': 3.2.0(graphql@16.8.2)
@@ -1993,6 +2044,10 @@ snapshots:
       cross-inspect: 1.0.1
       graphql: 16.8.2
       tslib: 2.8.1
+
+  '@graphql-typed-document-node/core@3.2.0(graphql@16.13.2)':
+    dependencies:
+      graphql: 16.13.2
 
   '@graphql-typed-document-node/core@3.2.0(graphql@16.8.2)':
     dependencies:
@@ -2733,7 +2788,23 @@ snapshots:
       lru-cache: 10.4.3
       tslib: 2.8.1
 
-  graphql@16.13.1: {}
+  graphql-yoga@5.21.0(graphql@16.13.2):
+    dependencies:
+      '@envelop/core': 5.5.1
+      '@envelop/instrumentation': 1.0.0
+      '@graphql-tools/executor': 1.5.1(graphql@16.13.2)
+      '@graphql-tools/schema': 10.0.31(graphql@16.13.2)
+      '@graphql-tools/utils': 10.11.0(graphql@16.13.2)
+      '@graphql-yoga/logger': 2.0.1
+      '@graphql-yoga/subscription': 5.0.5
+      '@whatwg-node/fetch': 0.10.13
+      '@whatwg-node/promise-helpers': 1.3.2
+      '@whatwg-node/server': 0.10.18
+      graphql: 16.13.2
+      lru-cache: 10.4.3
+      tslib: 2.8.1
+
+  graphql@16.13.2: {}
 
   graphql@16.8.2: {}
 

--- a/scripts/dev-local.sh
+++ b/scripts/dev-local.sh
@@ -20,6 +20,12 @@ echo "Syncing deployment addresses..."
 cp packages/config/src/deployments/registries_31337.json "$ROOT_DIR/config/deployments/registries_31337.json"
 cp packages/config/src/deployments/token_addresses.json "$ROOT_DIR/config/deployments/token_addresses.json"
 
+# Let Anvil settle the last seeded block before Ponder reads it
+sleep 1
+
+# Wipe Ponder's database so it re-indexes from block 0 against the fresh Anvil
+rm -rf "$ROOT_DIR/.ponder/pglite"
+
 # Start Ponder
 echo "Starting Ponder indexer..."
 cd "$ROOT_DIR"

--- a/src/api/asset/index.ts
+++ b/src/api/asset/index.ts
@@ -1,0 +1,2 @@
+export { typeDefs } from "./typeDefs.js";
+export { resolvers } from "./resolvers.js";

--- a/src/api/asset/resolvers.ts
+++ b/src/api/asset/resolvers.ts
@@ -1,0 +1,22 @@
+import schema from "ponder:schema";
+import { byId, queryList } from "../helpers.js";
+
+export const resolvers = {
+  Query: {
+    assetEntitys: (_: any, a: any) => queryList(schema.AssetEntity, a.where, a.orderBy, a.orderDirection, a.limit, a.offset),
+
+    asset_SubscriptionAddeds:    (_: any, a: any) => queryList(schema.Asset_SubscriptionAdded, a.where, a.orderBy, a.orderDirection, a.limit, a.offset),
+    asset_SubscriptionExtendeds: (_: any, a: any) => queryList(schema.Asset_SubscriptionExtended, a.where, a.orderBy, a.orderDirection, a.limit, a.offset),
+    asset_CreatorFeeClaimeds:    (_: any, a: any) => queryList(schema.Asset_CreatorFeeClaimed, a.where, a.orderBy, a.orderDirection, a.limit, a.offset),
+    asset_SubscriptionPriceUpdateds: (_: any, a: any) => queryList(schema.Asset_SubscriptionPriceUpdated, a.where, a.orderBy, a.orderDirection, a.limit, a.offset),
+    asset_SubscriptionRevokeds:  (_: any, a: any) => queryList(schema.Asset_SubscriptionRevoked, a.where, a.orderBy, a.orderDirection, a.limit, a.offset),
+    asset_SubscriptionCancelleds: (_: any, a: any) => queryList(schema.Asset_SubscriptionCancelled, a.where, a.orderBy, a.orderDirection, a.limit, a.offset),
+    asset_OwnershipTransferreds: (_: any, a: any) => queryList(schema.Asset_OwnershipTransferred, a.where, a.orderBy, a.orderDirection, a.limit, a.offset),
+  },
+
+  AssetEntity: {
+    registry:      (parent: any) => byId(schema.RegistryEntity, parent.registryId),
+    subscriptions: (parent: any, a: any) =>
+      queryList(schema.Subscription, { AND: [{ assetId: parent.id }, a.where].filter(Boolean) }, a.orderBy, a.orderDirection, a.limit, a.offset),
+  },
+};

--- a/src/api/asset/typeDefs.ts
+++ b/src/api/asset/typeDefs.ts
@@ -1,0 +1,96 @@
+export const typeDefs = /* GraphQL */ `
+  type AssetEntity {
+    id: String! chainId: Int! assetId: String! address: String!
+    registryId: String! registryAddress: String! owner: String!
+    subscriptionPrice: BigInt! tokenAddress: String!
+    registry: RegistryEntity
+    subscriptions(where: SubscriptionFilter, orderBy: String, orderDirection: String, limit: Int, offset: Int): SubscriptionPage
+  }
+  type AssetEntityPage { items: [AssetEntity!]! pageInfo: PageInfo! totalCount: Int! }
+  input AssetEntityFilter {
+    id: String  chainId: Int  assetId: String  address: Address
+    registryId: String  registryAddress: Address  owner: Address
+  }
+
+  type Asset_SubscriptionAdded {
+    id: String! chainId: Int! subscriber: String! payer: String!
+    startTime: BigInt! endTime: BigInt! nonce: BigInt!
+    assetAddress: Address! blockNumber: BigInt! blockTimestamp: BigInt!
+  }
+  type Asset_SubscriptionAddedPage { items: [Asset_SubscriptionAdded!]! pageInfo: PageInfo! totalCount: Int! }
+  input Asset_SubscriptionAddedFilter {
+    id: String  chainId: Int  subscriber: String  payer: Address  assetAddress: Address
+  }
+
+  type Asset_SubscriptionExtended {
+    id: String! chainId: Int! subscriber: String! endTime: BigInt!
+    assetAddress: Address! blockNumber: BigInt! blockTimestamp: BigInt!
+  }
+  type Asset_SubscriptionExtendedPage { items: [Asset_SubscriptionExtended!]! pageInfo: PageInfo! totalCount: Int! }
+  input Asset_SubscriptionExtendedFilter {
+    id: String  chainId: Int  subscriber: String  assetAddress: Address
+  }
+
+  type Asset_CreatorFeeClaimed {
+    id: String! chainId: Int! subscriber: String! amount: BigInt!
+    assetAddress: Address! blockNumber: BigInt! blockTimestamp: BigInt!
+  }
+  type Asset_CreatorFeeClaimedPage { items: [Asset_CreatorFeeClaimed!]! pageInfo: PageInfo! totalCount: Int! }
+  input Asset_CreatorFeeClaimedFilter {
+    id: String  chainId: Int  subscriber: String  assetAddress: Address
+  }
+
+  type Asset_SubscriptionPriceUpdated {
+    id: String! chainId: Int! newSubscriptionPrice: BigInt!
+    assetAddress: Address! blockNumber: BigInt! blockTimestamp: BigInt!
+  }
+  type Asset_SubscriptionPriceUpdatedPage { items: [Asset_SubscriptionPriceUpdated!]! pageInfo: PageInfo! totalCount: Int! }
+  input Asset_SubscriptionPriceUpdatedFilter {
+    id: String  chainId: Int  assetAddress: Address
+  }
+
+  type Asset_SubscriptionRevoked {
+    id: String! chainId: Int! subscriber: String!
+    assetAddress: Address! blockNumber: BigInt! blockTimestamp: BigInt!
+  }
+  type Asset_SubscriptionRevokedPage { items: [Asset_SubscriptionRevoked!]! pageInfo: PageInfo! totalCount: Int! }
+  input Asset_SubscriptionRevokedFilter {
+    id: String  chainId: Int  subscriber: String  assetAddress: Address
+  }
+
+  type Asset_SubscriptionCancelled {
+    id: String! chainId: Int! subscriber: String!
+    assetAddress: Address! blockNumber: BigInt! blockTimestamp: BigInt!
+  }
+  type Asset_SubscriptionCancelledPage { items: [Asset_SubscriptionCancelled!]! pageInfo: PageInfo! totalCount: Int! }
+  input Asset_SubscriptionCancelledFilter {
+    id: String  chainId: Int  subscriber: String  assetAddress: Address
+  }
+
+  type Asset_OwnershipTransferred {
+    id: String! chainId: Int! previousOwner: String! newOwner: String!
+    assetAddress: Address! blockNumber: BigInt! blockTimestamp: BigInt!
+  }
+  type Asset_OwnershipTransferredPage { items: [Asset_OwnershipTransferred!]! pageInfo: PageInfo! totalCount: Int! }
+  input Asset_OwnershipTransferredFilter {
+    id: String  chainId: Int  previousOwner: Address  newOwner: Address  assetAddress: Address
+  }
+
+  extend type Query {
+    assetEntitys(where: AssetEntityFilter, orderBy: String, orderDirection: String, limit: Int, offset: Int): AssetEntityPage!
+
+    asset_SubscriptionAddeds(where: Asset_SubscriptionAddedFilter, orderBy: String, orderDirection: String, limit: Int, offset: Int): Asset_SubscriptionAddedPage!
+
+    asset_SubscriptionExtendeds(where: Asset_SubscriptionExtendedFilter, orderBy: String, orderDirection: String, limit: Int, offset: Int): Asset_SubscriptionExtendedPage!
+
+    asset_CreatorFeeClaimeds(where: Asset_CreatorFeeClaimedFilter, orderBy: String, orderDirection: String, limit: Int, offset: Int): Asset_CreatorFeeClaimedPage!
+
+    asset_SubscriptionPriceUpdateds(where: Asset_SubscriptionPriceUpdatedFilter, orderBy: String, orderDirection: String, limit: Int, offset: Int): Asset_SubscriptionPriceUpdatedPage!
+
+    asset_SubscriptionRevokeds(where: Asset_SubscriptionRevokedFilter, orderBy: String, orderDirection: String, limit: Int, offset: Int): Asset_SubscriptionRevokedPage!
+
+    asset_SubscriptionCancelleds(where: Asset_SubscriptionCancelledFilter, orderBy: String, orderDirection: String, limit: Int, offset: Int): Asset_SubscriptionCancelledPage!
+
+    asset_OwnershipTransferreds(where: Asset_OwnershipTransferredFilter, orderBy: String, orderDirection: String, limit: Int, offset: Int): Asset_OwnershipTransferredPage!
+  }
+`;

--- a/src/api/helpers.ts
+++ b/src/api/helpers.ts
@@ -1,0 +1,105 @@
+import { db } from "ponder:api";
+import { and, eq, asc, desc, count } from "ponder";
+import { GraphQLScalarType, Kind } from "graphql";
+
+// ── Scalars ───────────────────────────────────────────────────────────────────
+
+export const BigIntScalar = new GraphQLScalarType({
+  name: "BigInt",
+  serialize: (v: unknown) => String(v),
+  parseValue: (v: unknown) => BigInt(String(v)),
+  parseLiteral: (ast) =>
+    ast.kind === Kind.STRING || ast.kind === Kind.INT ? BigInt(ast.value) : null,
+});
+
+export const JSONScalar = new GraphQLScalarType({
+  name: "JSON",
+  serialize: (v) => v,
+  parseValue: (v) => v,
+  parseLiteral: (ast) => ast,
+});
+
+// ── Where-clause builder ──────────────────────────────────────────────────────
+
+export const AddressScalar = new GraphQLScalarType({
+  name: "Address",
+  serialize: (v: unknown) => String(v),
+  parseValue: (v: unknown) => String(v).toLowerCase(),
+  parseLiteral: (ast) => ast.kind === Kind.STRING ? ast.value.toLowerCase() : null,
+});
+
+export function buildWhere(table: any, filter: any): any {
+  if (!filter) return undefined;
+  const conds = Object.entries(filter)
+    .filter(([, value]) => value !== undefined && value !== null)
+    .map(([key, value]) => {
+      const col = table[key];
+      return col ? eq(col, value as any) : undefined;
+    })
+    .filter(Boolean);
+
+  if (!conds.length) return undefined;
+  return conds.length === 1 ? conds[0] : and(...(conds as any[]));
+}
+
+// ── Query helpers ─────────────────────────────────────────────────────────────
+
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 1000;
+
+export async function queryList(
+  table: any,
+  filter: any,
+  orderBy?: string,
+  orderDirection?: string,
+  limit?: number,
+  offset?: number,
+) {
+  const where = buildWhere(table, filter);
+  const n = Math.min(limit ?? DEFAULT_LIMIT, MAX_LIMIT);
+  const off = offset ?? 0;
+
+  let q = (db as any).select().from(table).where(where);
+  if (orderBy && table[orderBy]) {
+    q = q.orderBy(orderDirection?.toLowerCase() === "desc" ? desc(table[orderBy]) : asc(table[orderBy]));
+  }
+
+  const [items, [{ total }]] = await Promise.all([
+    q.limit(n).offset(off),
+    (db as any).select({ total: count() }).from(table).where(where),
+  ]);
+
+  const totalCount = Number(total ?? 0);
+  return {
+    items,
+    pageInfo: { hasNextPage: off + items.length < totalCount, hasPreviousPage: off > 0 },
+    totalCount,
+  };
+}
+
+export function byId(table: any, id: string): Promise<any> {
+  return (db as any).select().from(table).where(eq(table.id, id)).limit(1)
+    .then((rows: any[]) => rows[0] ?? null);
+}
+
+// ── Meta ──────────────────────────────────────────────────────────────────────
+
+function decodeCheckpoint(cp: string) {
+  return {
+    blockTimestamp: Number(cp.slice(0, 10)),
+    blockNumber: Number(cp.slice(26, 42)),
+  };
+}
+
+export async function getMeta() {
+  const rows = (await (db as any).execute(
+    "SELECT chain_name, chain_id, latest_checkpoint FROM _ponder_checkpoint",
+  )).rows as { chain_name: string; chain_id: string; latest_checkpoint: string }[];
+
+  const status: Record<string, unknown> = {};
+  for (const { chain_name, chain_id, latest_checkpoint } of rows) {
+    const { blockNumber, blockTimestamp } = decodeCheckpoint(latest_checkpoint);
+    status[chain_name] = { id: Number(chain_id), block: { number: blockNumber, timestamp: blockTimestamp } };
+  }
+  return { status };
+}

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -2,6 +2,7 @@ import { db } from "ponder:api";
 import schema from "ponder:schema";
 import { Hono } from "hono";
 import { client, graphql } from "ponder";
+import { graphqlV2 } from "./v2.js";
 
 const app = new Hono();
 
@@ -10,5 +11,6 @@ app.use("/sql/*", client({ db, schema }));
 app.use("/", graphql({ db, schema }));
 app.use("/graphql", graphql({ db, schema }));
 
+app.use("/v2/graphql", graphqlV2);
 
 export default app;

--- a/src/api/registry/index.ts
+++ b/src/api/registry/index.ts
@@ -1,0 +1,2 @@
+export { typeDefs } from "./typeDefs.js";
+export { resolvers } from "./resolvers.js";

--- a/src/api/registry/resolvers.ts
+++ b/src/api/registry/resolvers.ts
@@ -1,0 +1,18 @@
+import schema from "ponder:schema";
+import { byId, queryList } from "../helpers.js";
+
+export const resolvers = {
+  Query: {
+    registryEntitys: (_: any, a: any) => queryList(schema.RegistryEntity, a.where, a.orderBy, a.orderDirection, a.limit, a.offset),
+
+    assetRegistry_AssetCreateds:         (_: any, a: any) => queryList(schema.AssetRegistry_AssetCreated, a.where, a.orderBy, a.orderDirection, a.limit, a.offset),
+    assetRegistry_OwnershipTransferreds: (_: any, a: any) => queryList(schema.AssetRegistry_OwnershipTransferred, a.where, a.orderBy, a.orderDirection, a.limit, a.offset),
+    assetRegistry_RegistryFeeShareUpdateds: (_: any, a: any) => queryList(schema.AssetRegistry_RegistryFeeShareUpdated, a.where, a.orderBy, a.orderDirection, a.limit, a.offset),
+    assetRegistry_RegistryFeeClaimedBatchs: (_: any, a: any) => queryList(schema.AssetRegistry_RegistryFeeClaimedBatch, a.where, a.orderBy, a.orderDirection, a.limit, a.offset),
+  },
+
+  RegistryEntity: {
+    assets: (parent: any, a: any) =>
+      queryList(schema.AssetEntity, { AND: [{ registryId: parent.id }, a.where].filter(Boolean) }, a.orderBy, a.orderDirection, a.limit, a.offset),
+  },
+};

--- a/src/api/registry/typeDefs.ts
+++ b/src/api/registry/typeDefs.ts
@@ -1,0 +1,59 @@
+export const typeDefs = /* GraphQL */ `
+  type RegistryEntity {
+    id: String! chainId: Int! address: String! owner: String registryFeeShare: BigInt
+    assets(where: AssetEntityFilter, orderBy: String, orderDirection: String, limit: Int, offset: Int): AssetEntityPage
+  }
+  type RegistryEntityPage { items: [RegistryEntity!]! pageInfo: PageInfo! totalCount: Int! }
+  input RegistryEntityFilter {
+    id: String  chainId: Int  address: Address  owner: Address
+  }
+
+  type AssetRegistry_AssetCreated {
+    id: String! chainId: Int! assetId: String! asset: String!
+    subscriptionPrice: BigInt! tokenAddress: String! owner: String!
+    registryAddress: String! blockNumber: BigInt! blockTimestamp: BigInt!
+  }
+  type AssetRegistry_AssetCreatedPage { items: [AssetRegistry_AssetCreated!]! pageInfo: PageInfo! totalCount: Int! }
+  input AssetRegistry_AssetCreatedFilter {
+    id: String  chainId: Int  assetId: String  asset: Address  owner: Address  registryAddress: Address
+  }
+
+  type AssetRegistry_OwnershipTransferred {
+    id: String! chainId: Int! previousOwner: String! newOwner: String!
+    registryAddress: String! blockNumber: BigInt! blockTimestamp: BigInt!
+  }
+  type AssetRegistry_OwnershipTransferredPage { items: [AssetRegistry_OwnershipTransferred!]! pageInfo: PageInfo! totalCount: Int! }
+  input AssetRegistry_OwnershipTransferredFilter {
+    id: String  chainId: Int  previousOwner: Address  newOwner: Address  registryAddress: Address
+  }
+
+  type AssetRegistry_RegistryFeeShareUpdated {
+    id: String! chainId: Int! newRegistryFeeShare: BigInt!
+    registryAddress: String! blockNumber: BigInt! blockTimestamp: BigInt!
+  }
+  type AssetRegistry_RegistryFeeShareUpdatedPage { items: [AssetRegistry_RegistryFeeShareUpdated!]! pageInfo: PageInfo! totalCount: Int! }
+  input AssetRegistry_RegistryFeeShareUpdatedFilter {
+    id: String  chainId: Int  newRegistryFeeShare: BigInt  registryAddress: Address
+  }
+
+  type AssetRegistry_RegistryFeeClaimedBatch {
+    id: String! chainId: Int! assetId: String! totalAmount: BigInt!
+    registryAddress: String! blockNumber: BigInt! blockTimestamp: BigInt!
+  }
+  type AssetRegistry_RegistryFeeClaimedBatchPage { items: [AssetRegistry_RegistryFeeClaimedBatch!]! pageInfo: PageInfo! totalCount: Int! }
+  input AssetRegistry_RegistryFeeClaimedBatchFilter {
+    id: String  chainId: Int  assetId: String  registryAddress: Address
+  }
+
+  extend type Query {
+    registryEntitys(where: RegistryEntityFilter, orderBy: String, orderDirection: String, limit: Int, offset: Int): RegistryEntityPage!
+
+    assetRegistry_AssetCreateds(where: AssetRegistry_AssetCreatedFilter, orderBy: String, orderDirection: String, limit: Int, offset: Int): AssetRegistry_AssetCreatedPage!
+
+    assetRegistry_OwnershipTransferreds(where: AssetRegistry_OwnershipTransferredFilter, orderBy: String, orderDirection: String, limit: Int, offset: Int): AssetRegistry_OwnershipTransferredPage!
+
+    assetRegistry_RegistryFeeShareUpdateds(where: AssetRegistry_RegistryFeeShareUpdatedFilter, orderBy: String, orderDirection: String, limit: Int, offset: Int): AssetRegistry_RegistryFeeShareUpdatedPage!
+
+    assetRegistry_RegistryFeeClaimedBatchs(where: AssetRegistry_RegistryFeeClaimedBatchFilter, orderBy: String, orderDirection: String, limit: Int, offset: Int): AssetRegistry_RegistryFeeClaimedBatchPage!
+  }
+`;

--- a/src/api/subscription/index.ts
+++ b/src/api/subscription/index.ts
@@ -1,0 +1,2 @@
+export { typeDefs } from "./typeDefs.js";
+export { resolvers } from "./resolvers.js";

--- a/src/api/subscription/resolvers.ts
+++ b/src/api/subscription/resolvers.ts
@@ -1,0 +1,12 @@
+import schema from "ponder:schema";
+import { byId, queryList } from "../helpers.js";
+
+export const resolvers = {
+  Query: {
+    subscriptions: (_: any, a: any) => queryList(schema.Subscription, a.where, a.orderBy, a.orderDirection, a.limit, a.offset),
+  },
+
+  Subscription: {
+    asset: (parent: any) => byId(schema.AssetEntity, parent.assetId),
+  },
+};

--- a/src/api/subscription/typeDefs.ts
+++ b/src/api/subscription/typeDefs.ts
@@ -1,0 +1,17 @@
+export const typeDefs = /* GraphQL */ `
+  type Subscription {
+    id: String! chainId: Int! assetId: String! subscriber: String! payer: String!
+    startTime: BigInt! endTime: BigInt! nonce: BigInt! isActive: Boolean!
+    asset: AssetEntity
+  }
+  
+  type SubscriptionPage { items: [Subscription!]! pageInfo: PageInfo! totalCount: Int! }
+  
+  input SubscriptionFilter {
+    id: String  chainId: Int  assetId: String  subscriber: String  payer: Address
+  }
+
+  extend type Query {
+    subscriptions(where: SubscriptionFilter, orderBy: String, orderDirection: String, limit: Int, offset: Int): SubscriptionPage!
+  }
+`;

--- a/src/api/v2.ts
+++ b/src/api/v2.ts
@@ -1,0 +1,39 @@
+import { createYoga, createSchema } from "graphql-yoga";
+import { createMiddleware } from "hono/factory";
+import { BigIntScalar, JSONScalar, AddressScalar, getMeta } from "./helpers.js";
+import * as registry from "./registry/index.js";
+import * as asset from "./asset/index.js";
+import * as subscription from "./subscription/index.js";
+
+const baseDefs = /* GraphQL */ `
+  scalar BigInt
+  scalar JSON
+  scalar Address
+
+  type PageInfo { hasNextPage: Boolean! hasPreviousPage: Boolean! }
+  type Meta { status: JSON }
+
+  type Query { _meta: Meta }
+`;
+
+const yoga = createYoga({
+  graphqlEndpoint: "*",
+  schema: createSchema({
+    typeDefs: [baseDefs, registry.typeDefs, asset.typeDefs, subscription.typeDefs],
+    resolvers: [
+      { BigInt: BigIntScalar, JSON: JSONScalar, Address: AddressScalar, Query: { _meta: () => getMeta() } },
+      registry.resolvers,
+      asset.resolvers,
+      subscription.resolvers,
+    ],
+  }),
+  maskedErrors: process.env.NODE_ENV === "production",
+  logging: false,
+  graphiql: true,
+  parserAndValidationCache: false,
+});
+
+export const graphqlV2 = createMiddleware(async (c) => {
+  const response = await yoga.handle(c.req.raw);
+  return new Response(response.body, { status: 200, headers: new Headers(response.headers) });
+});


### PR DESCRIPTION
## Summary

- Adds a custom GraphQL endpoint at `/v2/graphql` (graphql-yoga + Drizzle) alongside the existing auto-generated `/graphql`
- Organises API code by domain: `api/registry/`, `api/asset/`, `api/subscription/` — each with `typeDefs.ts`, `resolvers.ts`, `index.ts`
- Filters support exact equality only (no `_gt`/`_lt`/`_in`/AND/OR) for a simpler, more predictable API surface
- Introduces an `Address` scalar that lowercases inputs at the schema boundary, making all address filters case-insensitive
- `_meta { status }` returns live per-chain sync state decoded from `_ponder_checkpoint`
- Fixes `dev:local` re-indexing: wipes `.ponder/pglite` on each run so Ponder doesn't skip historical events due to a stale checkpoint, and adds a 1s settle delay to avoid the `BlockNotFoundError` race on the last seeded block

