### PR TITLE
feat(indexer): per-nonce subscriptions, active query, GraphQL type renames

### DIFF
--- a/ponder.schema.ts
+++ b/ponder.schema.ts
@@ -39,26 +39,28 @@ export const AssetEntity = onchainTable("asset_entity", (t) => ({
   assetIdIdx: index().on(table.assetId),
 }));
 
-// Tracks the current state of a subscriber's subscription to an asset.
-// One row per asset–subscriber pair (not per nonce). When terms change mid-subscription
-// (price, payer, fee share), the contract creates a new nonce but the indexer preserves
-// the original startTime to show unbroken continuity. payer and nonce always reflect
-// the latest on-chain subscription record.
+// One row per asset–subscriber–nonce. The contract issues a new nonce whenever
+// terms change mid-subscription (price, payer, fee share); each nonce is an
+// independent row. SubscriptionExtended updates the latest nonce's endTime.
+// Revoke/cancel marks all non-terminated rows isTerminated=true.
 export const Subscription = onchainTable("subscription", (t) => ({
-  id: t.text().primaryKey(),       // Composite: `${AssetEntity.id}_${subscriber}`
+  id: t.text().primaryKey(),       // Composite: `${AssetEntity.id}_${subscriber}_${nonce}`
   chainId: t.integer().notNull(),
   assetId: t.text().notNull(),     // Links to AssetEntity.id
   subscriber: t.text().notNull(),  // bytes32 subscriber identity hash
-  payer: t.text().notNull(),       // address that paid (latest nonce)
-  startTime: t.bigint().notNull(), // original start of unbroken subscription continuity
-  endTime: t.bigint().notNull(),   // current expiry (updated by SubscriptionAdded & SubscriptionExtended)
-  nonce: t.bigint().notNull(),     // latest on-chain nonce (increments when terms change)
-  isActive: t.boolean().notNull(), // false when revoked or cancelled
+  payer: t.text().notNull(),       // address that paid for this nonce
+  startTime: t.bigint().notNull(), // subscription start for this nonce
+  endTime: t.bigint().notNull(),   // current expiry (updated by SubscriptionExtended)
+  nonce: t.bigint().notNull(),     // on-chain nonce (increments when terms change)
+  isTerminated: t.boolean().notNull(), // true when revoked or cancelled
 }), (table) => ({
   chainIdIdx: index().on(table.chainId),
   assetIdIdx: index().on(table.assetId),
   subscriberIdx: index().on(table.subscriber),
   payerIdx: index().on(table.payer),
+  nonceIdx: index().on(table.nonce),
+  startTimeIdx: index().on(table.startTime),
+  endTimeIdx: index().on(table.endTime),
 }));
 
 // --- Relations ---

--- a/ponder.schema.ts
+++ b/ponder.schema.ts
@@ -42,7 +42,8 @@ export const AssetEntity = onchainTable("asset_entity", (t) => ({
 // One row per asset–subscriber–nonce. The contract issues a new nonce whenever
 // terms change mid-subscription (price, payer, fee share); each nonce is an
 // independent row. SubscriptionExtended updates the latest nonce's endTime.
-// Revoke/cancel marks all non-terminated rows isTerminated=true.
+// Revoke truncates endTime and sets isRevoked=true; cancel only truncates endTime.
+// Future nonces deleted by revoke/cancel are removed from the DB entirely.
 export const Subscription = onchainTable("subscription", (t) => ({
   id: t.text().primaryKey(),       // Composite: `${AssetEntity.id}_${subscriber}_${nonce}`
   chainId: t.integer().notNull(),
@@ -50,9 +51,9 @@ export const Subscription = onchainTable("subscription", (t) => ({
   subscriber: t.text().notNull(),  // bytes32 subscriber identity hash
   payer: t.text().notNull(),       // address that paid for this nonce
   startTime: t.bigint().notNull(), // subscription start for this nonce
-  endTime: t.bigint().notNull(),   // current expiry (updated by SubscriptionExtended)
+  endTime: t.bigint().notNull(),   // current expiry (updated by SubscriptionExtended; truncated on revoke/cancel)
   nonce: t.bigint().notNull(),     // on-chain nonce (increments when terms change)
-  isTerminated: t.boolean().notNull(), // true when revoked or cancelled
+  isRevoked: t.boolean().notNull(), // true only when owner explicitly revoked (SubscriptionRevoked)
 }), (table) => ({
   chainIdIdx: index().on(table.chainId),
   assetIdIdx: index().on(table.assetId),

--- a/scripts/dev-local.sh
+++ b/scripts/dev-local.sh
@@ -10,15 +10,14 @@ echo "Starting Anvil..."
 anvil &
 ANVIL_PID=$!
 
-# Seed local environment from the submodule (seed-local.sh polls until anvil is ready)
+# Seed local environment (polls until anvil is ready, then runs all scenarios)
 echo "Seeding local environment..."
-cd "$SUBMODULE_DIR"
-bash scripts/seed-local.sh
+bash "$SCRIPT_DIR/seed-local.sh"
 
 # Copy updated deployment addresses into the indexer's config
 echo "Syncing deployment addresses..."
-cp packages/config/src/deployments/registries_31337.json "$ROOT_DIR/config/deployments/registries_31337.json"
-cp packages/config/src/deployments/token_addresses.json "$ROOT_DIR/config/deployments/token_addresses.json"
+cp "$SUBMODULE_DIR/packages/config/src/deployments/registries_31337.json" "$ROOT_DIR/config/deployments/registries_31337.json"
+cp "$SUBMODULE_DIR/packages/config/src/deployments/token_addresses.json" "$ROOT_DIR/config/deployments/token_addresses.json"
 
 # Let Anvil settle the last seeded block before Ponder reads it
 sleep 1

--- a/scripts/seed-local.sh
+++ b/scripts/seed-local.sh
@@ -1,0 +1,175 @@
+#!/bin/bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INDEXER_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+RAILS_DIR="$INDEXER_ROOT/open-creator-rails"
+
+export RPC_URL="http://127.0.0.1:8545"
+export PRIVATE_KEY="0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+
+DEPLOYER_ADDR="0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
+SUB1_PK="0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d"
+SUB2_PK="0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a"
+SUB1_ADDR="0x70997970C51812dc3A010C7d01b50e0d17dc79C8"
+SUB2_ADDR="0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC"
+SUB1_HASH=$(cast keccak "$SUB1_ADDR")
+SUB2_HASH=$(cast keccak "$SUB2_ADDR")
+
+cd "$RAILS_DIR"
+
+# ── Base deployment ────────────────────────────────────────────────────────────
+
+echo "Waiting for Anvil..."
+while ! cast chain-id --rpc-url $RPC_URL > /dev/null 2>&1; do sleep 1; done
+echo "Anvil is up!"
+
+# Clear stale deployment JSON from previous runs so entries don't accumulate
+echo '[]' > packages/config/src/deployments/registries_31337.json
+echo '{}' > packages/config/src/deployments/token_addresses.json
+
+echo "1. Deploying Test Token..."
+./scripts/deployTestToken.sh
+
+echo "2. Deploying Registry (80% Creator / 20% Registry)..."
+./scripts/deployRegistry.sh 80 20
+
+TOKEN_ADDR=$(jq -r '.["31337"]' packages/config/src/deployments/token_addresses.json)
+REGISTRY_ADDR=$(jq -r '.[0].address' packages/config/src/deployments/registries_31337.json)
+
+echo "3. Creating Assets..."
+for i in {1..8}; do
+  price=$((i * 2))
+  ./scripts/createAsset.sh 0 "local_asset_$i" $price $TOKEN_ADDR $DEPLOYER_ADDR > /dev/null
+  echo "  local_asset_$i (price: $price tokens/sec)"
+done
+
+echo "4. Minting tokens to subscribers..."
+./scripts/mintTestToken.sh $SUB1_ADDR 50000000000000000000000 > /dev/null
+./scripts/mintTestToken.sh $SUB2_ADDR 50000000000000000000000 > /dev/null
+
+# Helper to look up deployed asset address by human-readable ID
+asset_addr() {
+  local id_hash
+  id_hash=$(cast keccak "$1")
+  jq -r --arg h "$id_hash" 'first(.[0].assets[] | select(.assetIdHash == $h) | .address)' \
+    packages/config/src/deployments/registries_31337.json
+}
+
+# ── Scenario: Active subscriptions ────────────────────────────────────────────
+echo ""
+echo "=== Scenario: Active Subscriptions ==="
+
+echo "  Sub1 -> asset_1 (1h)"
+./scripts/subscribe.sh 0 "local_asset_1" $SUB1_ADDR 3600 $SUB1_PK > /dev/null
+echo "  Sub2 -> asset_1 (2h)"
+./scripts/subscribe.sh 0 "local_asset_1" $SUB2_ADDR 7200 $SUB2_PK > /dev/null
+echo "  Sub1 top-up -> asset_1 (+1h, same terms -> SubscriptionExtended)"
+./scripts/subscribe.sh 0 "local_asset_1" $SUB1_ADDR 3600 $SUB1_PK > /dev/null
+
+# ── Scenario: Revoked subscription ────────────────────────────────────────────
+echo ""
+echo "=== Scenario: Revoke ==="
+
+echo "  Sub1 -> asset_2 (1h)"
+./scripts/subscribe.sh 0 "local_asset_2" $SUB1_ADDR 3600 $SUB1_PK > /dev/null
+ASSET2_ADDR=$(asset_addr "local_asset_2")
+cast send $ASSET2_ADDR "revokeSubscription(bytes32)" $SUB1_HASH \
+  --rpc-url $RPC_URL --private-key $PRIVATE_KEY > /dev/null
+echo "  Asset owner revoked Sub1 from asset_2 (isRevoked=true)"
+
+# ── Scenario: Cancelled subscription ──────────────────────────────────────────
+echo ""
+echo "=== Scenario: Cancel ==="
+
+echo "  Sub2 -> asset_2 (1h)"
+./scripts/subscribe.sh 0 "local_asset_2" $SUB2_ADDR 3600 $SUB2_PK > /dev/null
+cast send $REGISTRY_ADDR "cancelSubscription(bytes32,bytes32)" \
+  "$(cast keccak "local_asset_2")" $SUB2_HASH \
+  --rpc-url $RPC_URL --private-key $PRIVATE_KEY > /dev/null
+echo "  Registry cancelled Sub2 from asset_2 (isRevoked=false, endTime truncated)"
+
+# ── Scenario: Re-subscribe after cancel ───────────────────────────────────────
+echo ""
+echo "=== Scenario: Re-subscribe After Cancel (nonce reuse) ==="
+
+echo "  Sub1 -> asset_3 (30m)"
+./scripts/subscribe.sh 0 "local_asset_3" $SUB1_ADDR 1800 $SUB1_PK > /dev/null
+cast send $REGISTRY_ADDR "cancelSubscription(bytes32,bytes32)" \
+  "$(cast keccak "local_asset_3")" $SUB1_HASH \
+  --rpc-url $RPC_URL --private-key $PRIVATE_KEY > /dev/null
+echo "  Cancelled, re-subscribing (contract reuses nonce 0)..."
+./scripts/subscribe.sh 0 "local_asset_3" $SUB1_ADDR 3600 $SUB1_PK > /dev/null
+echo "  Sub1 re-subscribed to asset_3"
+
+# ── Scenario: Price change → new nonce ────────────────────────────────────────
+echo ""
+echo "=== Scenario: Price Change (new nonce) ==="
+
+echo "  Sub1 -> asset_4 (1h) at original price"
+./scripts/subscribe.sh 0 "local_asset_4" $SUB1_ADDR 3600 $SUB1_PK > /dev/null
+./scripts/setSubscriptionPrice.sh 0 "local_asset_4" 99 $PRIVATE_KEY > /dev/null
+echo "  Price updated to 99 — next subscribe chains a new nonce"
+./scripts/subscribe.sh 0 "local_asset_4" $SUB1_ADDR 3600 $SUB1_PK > /dev/null
+echo "  Sub1 re-subscribed to asset_4 (nonce 1)"
+
+# ── Scenario: Future subscription then revoke ─────────────────────────────────
+echo ""
+echo "=== Scenario: Future Subscription Revoked ==="
+
+echo "  Sub1 -> asset_5 (1h, nonce 0 active)"
+./scripts/subscribe.sh 0 "local_asset_5" $SUB1_ADDR 3600 $SUB1_PK > /dev/null
+./scripts/setSubscriptionPrice.sh 0 "local_asset_5" 50 $PRIVATE_KEY > /dev/null
+echo "  Sub1 -> asset_5 again (nonce 1 future, chains after nonce 0)"
+./scripts/subscribe.sh 0 "local_asset_5" $SUB1_ADDR 3600 $SUB1_PK > /dev/null
+ASSET5_ADDR=$(asset_addr "local_asset_5")
+cast send $ASSET5_ADDR "revokeSubscription(bytes32)" $SUB1_HASH \
+  --rpc-url $RPC_URL --private-key $PRIVATE_KEY > /dev/null
+echo "  Revoked (nonce 0 truncated + isRevoked=true; nonce 1 deleted from DB)"
+
+# ── Scenario: Future subscription then cancel ─────────────────────────────────
+echo ""
+echo "=== Scenario: Future Subscription Cancelled ==="
+
+echo "  Sub2 -> asset_6 (1h, nonce 0 active)"
+./scripts/subscribe.sh 0 "local_asset_6" $SUB2_ADDR 3600 $SUB2_PK > /dev/null
+./scripts/setSubscriptionPrice.sh 0 "local_asset_6" 50 $PRIVATE_KEY > /dev/null
+echo "  Sub2 -> asset_6 again (nonce 1 future, chains after nonce 0)"
+./scripts/subscribe.sh 0 "local_asset_6" $SUB2_ADDR 3600 $SUB2_PK > /dev/null
+cast send $REGISTRY_ADDR "cancelSubscription(bytes32,bytes32)" \
+  "$(cast keccak "local_asset_6")" $SUB2_HASH \
+  --rpc-url $RPC_URL --private-key $PRIVATE_KEY > /dev/null
+echo "  Cancelled (nonce 0 truncated, isRevoked=false; nonce 1 deleted from DB)"
+
+# ── Scenario: Active + future cancel then re-subscribe ────────────────────────
+echo ""
+echo "=== Scenario: Active + Future Cancel then Re-subscribe ==="
+
+# nonce 0: active
+echo "  Sub1 -> asset_7 (1h, nonce 0 active)"
+./scripts/subscribe.sh 0 "local_asset_7" $SUB1_ADDR 3600 $SUB1_PK > /dev/null
+# price change forces a new nonce on the next subscribe
+./scripts/setSubscriptionPrice.sh 0 "local_asset_7" 50 $PRIVATE_KEY > /dev/null
+# nonce 1: future (chains after nonce 0's endTime)
+echo "  Sub1 -> asset_7 again (nonce 1 future)"
+./scripts/subscribe.sh 0 "local_asset_7" $SUB1_ADDR 3600 $SUB1_PK > /dev/null
+# cancel: nonce 0 truncated + nonces[sub] decremented back to 0; nonce 1 deleted from DB
+cast send $REGISTRY_ADDR "cancelSubscription(bytes32,bytes32)" \
+  "$(cast keccak "local_asset_7")" $SUB1_HASH \
+  --rpc-url $RPC_URL --private-key $PRIVATE_KEY > /dev/null
+echo "  Cancelled — nonce 0 truncated, nonce 1 deleted, on-chain nonces[sub]=0"
+# re-subscribe: contract finds sub still in subscribers set, reads nonce 0's truncated endTime,
+# startTime=now != truncated endTime so increments → nonce 1 again; SubscriptionAdded(nonce=1)
+echo "  Re-subscribing (contract emits SubscriptionAdded nonce=1)..."
+./scripts/subscribe.sh 0 "local_asset_7" $SUB1_ADDR 3600 $SUB1_PK > /dev/null
+echo "  Sub1 re-subscribed to asset_7 (nonce 1 cleanly re-inserted in DB)"
+
+echo ""
+echo "Local seeding complete!"
+echo "  - asset_1: 2 active subscribers, Sub1 extended"
+echo "  - asset_2: Sub1 revoked, Sub2 cancelled"
+echo "  - asset_3: Sub1 cancelled then re-subscribed (nonce reuse)"
+echo "  - asset_4: Sub1 with price-change nonce chain"
+echo "  - asset_5: Sub1 revoked with a future nonce deleted"
+echo "  - asset_6: Sub2 cancelled with a future nonce deleted"
+echo "  - asset_7: Sub1 active+future cancelled then re-subscribed (nonce 1 re-inserted)"

--- a/src/api/asset/resolvers.ts
+++ b/src/api/asset/resolvers.ts
@@ -1,9 +1,9 @@
 import schema from "ponder:schema";
-import { byId, queryList } from "../helpers.js";
+import { byId, queryList, activeSubscriptionConditions } from "../helpers.js";
 
 export const resolvers = {
   Query: {
-    assetEntitys: (_: any, a: any) => queryList(schema.AssetEntity, a.where, a.orderBy, a.orderDirection, a.limit, a.offset),
+    assets: (_: any, a: any) => queryList(schema.AssetEntity, a.where, a.orderBy, a.orderDirection, a.limit, a.offset),
 
     asset_SubscriptionAddeds:    (_: any, a: any) => queryList(schema.Asset_SubscriptionAdded, a.where, a.orderBy, a.orderDirection, a.limit, a.offset),
     asset_SubscriptionExtendeds: (_: any, a: any) => queryList(schema.Asset_SubscriptionExtended, a.where, a.orderBy, a.orderDirection, a.limit, a.offset),
@@ -14,9 +14,11 @@ export const resolvers = {
     asset_OwnershipTransferreds: (_: any, a: any) => queryList(schema.Asset_OwnershipTransferred, a.where, a.orderBy, a.orderDirection, a.limit, a.offset),
   },
 
-  AssetEntity: {
+  Asset: {
     registry:      (parent: any) => byId(schema.RegistryEntity, parent.registryId),
     subscriptions: (parent: any, a: any) =>
-      queryList(schema.Subscription, { AND: [{ assetId: parent.id }, a.where].filter(Boolean) }, a.orderBy, a.orderDirection, a.limit, a.offset),
+      queryList(schema.Subscription, { ...a.where, assetId: parent.id }, a.orderBy, a.orderDirection, a.limit, a.offset),
+    activeSubscriptions: (parent: any, a: any) =>
+      queryList(schema.Subscription, { ...a.where, assetId: parent.id }, a.orderBy, a.orderDirection, a.limit, a.offset, activeSubscriptionConditions()),
   },
 };

--- a/src/api/asset/typeDefs.ts
+++ b/src/api/asset/typeDefs.ts
@@ -1,18 +1,23 @@
 export const typeDefs = /* GraphQL */ `
-  type AssetEntity {
+  type Asset {
+    # Stored Fields
     id: String! chainId: Int! assetId: String! address: String!
     registryId: String! registryAddress: String! owner: String!
     subscriptionPrice: BigInt! tokenAddress: String!
-    registry: RegistryEntity
+    
+    # Relations
+    registry: Registry
     subscriptions(where: SubscriptionFilter, orderBy: String, orderDirection: String, limit: Int, offset: Int): SubscriptionPage
+    activeSubscriptions(where: SubscriptionFilter, orderBy: String, orderDirection: String, limit: Int, offset: Int): SubscriptionPage
   }
-  type AssetEntityPage { items: [AssetEntity!]! pageInfo: PageInfo! totalCount: Int! }
-  input AssetEntityFilter {
+  type AssetPage { items: [Asset!]! pageInfo: PageInfo! totalCount: Int! }
+  input AssetFilter {
     id: String  chainId: Int  assetId: String  address: Address
     registryId: String  registryAddress: Address  owner: Address
   }
 
   type Asset_SubscriptionAdded {
+    # Stored Fields
     id: String! chainId: Int! subscriber: String! payer: String!
     startTime: BigInt! endTime: BigInt! nonce: BigInt!
     assetAddress: Address! blockNumber: BigInt! blockTimestamp: BigInt!
@@ -23,6 +28,7 @@ export const typeDefs = /* GraphQL */ `
   }
 
   type Asset_SubscriptionExtended {
+    # Stored Fields
     id: String! chainId: Int! subscriber: String! endTime: BigInt!
     assetAddress: Address! blockNumber: BigInt! blockTimestamp: BigInt!
   }
@@ -32,6 +38,7 @@ export const typeDefs = /* GraphQL */ `
   }
 
   type Asset_CreatorFeeClaimed {
+    # Stored Fields
     id: String! chainId: Int! subscriber: String! amount: BigInt!
     assetAddress: Address! blockNumber: BigInt! blockTimestamp: BigInt!
   }
@@ -41,6 +48,7 @@ export const typeDefs = /* GraphQL */ `
   }
 
   type Asset_SubscriptionPriceUpdated {
+    # Stored Fields
     id: String! chainId: Int! newSubscriptionPrice: BigInt!
     assetAddress: Address! blockNumber: BigInt! blockTimestamp: BigInt!
   }
@@ -50,6 +58,7 @@ export const typeDefs = /* GraphQL */ `
   }
 
   type Asset_SubscriptionRevoked {
+    # Stored Fields
     id: String! chainId: Int! subscriber: String!
     assetAddress: Address! blockNumber: BigInt! blockTimestamp: BigInt!
   }
@@ -59,6 +68,7 @@ export const typeDefs = /* GraphQL */ `
   }
 
   type Asset_SubscriptionCancelled {
+    # Stored Fields
     id: String! chainId: Int! subscriber: String!
     assetAddress: Address! blockNumber: BigInt! blockTimestamp: BigInt!
   }
@@ -68,6 +78,7 @@ export const typeDefs = /* GraphQL */ `
   }
 
   type Asset_OwnershipTransferred {
+    # Stored Fields
     id: String! chainId: Int! previousOwner: String! newOwner: String!
     assetAddress: Address! blockNumber: BigInt! blockTimestamp: BigInt!
   }
@@ -77,7 +88,7 @@ export const typeDefs = /* GraphQL */ `
   }
 
   extend type Query {
-    assetEntitys(where: AssetEntityFilter, orderBy: String, orderDirection: String, limit: Int, offset: Int): AssetEntityPage!
+    assets(where: AssetFilter, orderBy: String, orderDirection: String, limit: Int, offset: Int): AssetPage!
 
     asset_SubscriptionAddeds(where: Asset_SubscriptionAddedFilter, orderBy: String, orderDirection: String, limit: Int, offset: Int): Asset_SubscriptionAddedPage!
 

--- a/src/api/helpers.ts
+++ b/src/api/helpers.ts
@@ -48,7 +48,7 @@ export function buildWhere(table: any, filter: any): any {
 export function activeSubscriptionConditions() {
   const now = BigInt(Math.floor(Date.now() / 1000));
   return and(
-    eq(schema.Subscription.isTerminated, false),
+    eq(schema.Subscription.isRevoked, false),
     lt(schema.Subscription.startTime, now),
     gt(schema.Subscription.endTime, now),
   );

--- a/src/api/helpers.ts
+++ b/src/api/helpers.ts
@@ -1,5 +1,6 @@
 import { db } from "ponder:api";
-import { and, eq, asc, desc, count } from "ponder";
+import schema from "ponder:schema";
+import { and, eq, gt, lt, asc, desc, count } from "ponder";
 import { GraphQLScalarType, Kind } from "graphql";
 
 // ── Scalars ───────────────────────────────────────────────────────────────────
@@ -42,6 +43,17 @@ export function buildWhere(table: any, filter: any): any {
   return conds.length === 1 ? conds[0] : and(...(conds as any[]));
 }
 
+// ── Shared conditions ─────────────────────────────────────────────────────────
+
+export function activeSubscriptionConditions() {
+  const now = BigInt(Math.floor(Date.now() / 1000));
+  return and(
+    eq(schema.Subscription.isTerminated, false),
+    lt(schema.Subscription.startTime, now),
+    gt(schema.Subscription.endTime, now),
+  );
+}
+
 // ── Query helpers ─────────────────────────────────────────────────────────────
 
 const DEFAULT_LIMIT = 50;
@@ -54,8 +66,12 @@ export async function queryList(
   orderDirection?: string,
   limit?: number,
   offset?: number,
+  extraConditions?: any,
 ) {
-  const where = buildWhere(table, filter);
+  const filterWhere = buildWhere(table, filter);
+  const where = filterWhere && extraConditions
+    ? and(filterWhere, extraConditions)
+    : (filterWhere ?? extraConditions);
   const n = Math.min(limit ?? DEFAULT_LIMIT, MAX_LIMIT);
   const off = offset ?? 0;
 

--- a/src/api/registry/resolvers.ts
+++ b/src/api/registry/resolvers.ts
@@ -3,7 +3,7 @@ import { byId, queryList } from "../helpers.js";
 
 export const resolvers = {
   Query: {
-    registryEntitys: (_: any, a: any) => queryList(schema.RegistryEntity, a.where, a.orderBy, a.orderDirection, a.limit, a.offset),
+    registries: (_: any, a: any) => queryList(schema.RegistryEntity, a.where, a.orderBy, a.orderDirection, a.limit, a.offset),
 
     assetRegistry_AssetCreateds:         (_: any, a: any) => queryList(schema.AssetRegistry_AssetCreated, a.where, a.orderBy, a.orderDirection, a.limit, a.offset),
     assetRegistry_OwnershipTransferreds: (_: any, a: any) => queryList(schema.AssetRegistry_OwnershipTransferred, a.where, a.orderBy, a.orderDirection, a.limit, a.offset),
@@ -11,8 +11,8 @@ export const resolvers = {
     assetRegistry_RegistryFeeClaimedBatchs: (_: any, a: any) => queryList(schema.AssetRegistry_RegistryFeeClaimedBatch, a.where, a.orderBy, a.orderDirection, a.limit, a.offset),
   },
 
-  RegistryEntity: {
+  Registry: {
     assets: (parent: any, a: any) =>
-      queryList(schema.AssetEntity, { AND: [{ registryId: parent.id }, a.where].filter(Boolean) }, a.orderBy, a.orderDirection, a.limit, a.offset),
+      queryList(schema.AssetEntity, { ...a.where, registryId: parent.id }, a.orderBy, a.orderDirection, a.limit, a.offset),
   },
 };

--- a/src/api/registry/typeDefs.ts
+++ b/src/api/registry/typeDefs.ts
@@ -1,14 +1,18 @@
 export const typeDefs = /* GraphQL */ `
-  type RegistryEntity {
+  type Registry {
+    # Stored Fields
     id: String! chainId: Int! address: String! owner: String registryFeeShare: BigInt
-    assets(where: AssetEntityFilter, orderBy: String, orderDirection: String, limit: Int, offset: Int): AssetEntityPage
+    
+    # Relations
+    assets(where: AssetFilter, orderBy: String, orderDirection: String, limit: Int, offset: Int): AssetPage
   }
-  type RegistryEntityPage { items: [RegistryEntity!]! pageInfo: PageInfo! totalCount: Int! }
-  input RegistryEntityFilter {
+  type RegistryPage { items: [Registry!]! pageInfo: PageInfo! totalCount: Int! }
+  input RegistryFilter {
     id: String  chainId: Int  address: Address  owner: Address
   }
 
   type AssetRegistry_AssetCreated {
+    # Stored Fields
     id: String! chainId: Int! assetId: String! asset: String!
     subscriptionPrice: BigInt! tokenAddress: String! owner: String!
     registryAddress: String! blockNumber: BigInt! blockTimestamp: BigInt!
@@ -19,6 +23,7 @@ export const typeDefs = /* GraphQL */ `
   }
 
   type AssetRegistry_OwnershipTransferred {
+    # Stored Fields
     id: String! chainId: Int! previousOwner: String! newOwner: String!
     registryAddress: String! blockNumber: BigInt! blockTimestamp: BigInt!
   }
@@ -28,6 +33,7 @@ export const typeDefs = /* GraphQL */ `
   }
 
   type AssetRegistry_RegistryFeeShareUpdated {
+    # Stored Fields
     id: String! chainId: Int! newRegistryFeeShare: BigInt!
     registryAddress: String! blockNumber: BigInt! blockTimestamp: BigInt!
   }
@@ -37,6 +43,7 @@ export const typeDefs = /* GraphQL */ `
   }
 
   type AssetRegistry_RegistryFeeClaimedBatch {
+    # Stored Fields
     id: String! chainId: Int! assetId: String! totalAmount: BigInt!
     registryAddress: String! blockNumber: BigInt! blockTimestamp: BigInt!
   }
@@ -46,7 +53,7 @@ export const typeDefs = /* GraphQL */ `
   }
 
   extend type Query {
-    registryEntitys(where: RegistryEntityFilter, orderBy: String, orderDirection: String, limit: Int, offset: Int): RegistryEntityPage!
+    registries(where: RegistryFilter, orderBy: String, orderDirection: String, limit: Int, offset: Int): RegistryPage!
 
     assetRegistry_AssetCreateds(where: AssetRegistry_AssetCreatedFilter, orderBy: String, orderDirection: String, limit: Int, offset: Int): AssetRegistry_AssetCreatedPage!
 

--- a/src/api/subscription/resolvers.ts
+++ b/src/api/subscription/resolvers.ts
@@ -11,7 +11,7 @@ export const resolvers = {
     asset: (parent: any) => byId(schema.AssetEntity, parent.assetId),
     isActive: (parent: any) => {
       const now = BigInt(Math.floor(Date.now() / 1000));
-      return !parent.isTerminated && parent.startTime <= now && now < parent.endTime;
+      return !parent.isRevoked && parent.startTime <= now && now < parent.endTime;
     },
   },
 };

--- a/src/api/subscription/resolvers.ts
+++ b/src/api/subscription/resolvers.ts
@@ -1,12 +1,17 @@
 import schema from "ponder:schema";
-import { byId, queryList } from "../helpers.js";
+import { byId, queryList, activeSubscriptionConditions } from "../helpers.js";
 
 export const resolvers = {
   Query: {
     subscriptions: (_: any, a: any) => queryList(schema.Subscription, a.where, a.orderBy, a.orderDirection, a.limit, a.offset),
+    activeSubscriptions: (_: any, a: any) => queryList(schema.Subscription, a.where, a.orderBy, a.orderDirection, a.limit, a.offset, activeSubscriptionConditions()),
   },
 
   Subscription: {
     asset: (parent: any) => byId(schema.AssetEntity, parent.assetId),
+    isActive: (parent: any) => {
+      const now = BigInt(Math.floor(Date.now() / 1000));
+      return !parent.isTerminated && parent.startTime <= now && now < parent.endTime;
+    },
   },
 };

--- a/src/api/subscription/typeDefs.ts
+++ b/src/api/subscription/typeDefs.ts
@@ -2,7 +2,7 @@ export const typeDefs = /* GraphQL */ `
   type Subscription {
     # Stored Fields
     id: String! chainId: Int! assetId: String! subscriber: String! payer: String!
-    startTime: BigInt! endTime: BigInt! nonce: BigInt! isTerminated: Boolean!
+    startTime: BigInt! endTime: BigInt! nonce: BigInt! isRevoked: Boolean!
     
     # Computed
     isActive: Boolean!

--- a/src/api/subscription/typeDefs.ts
+++ b/src/api/subscription/typeDefs.ts
@@ -1,8 +1,14 @@
 export const typeDefs = /* GraphQL */ `
   type Subscription {
+    # Stored Fields
     id: String! chainId: Int! assetId: String! subscriber: String! payer: String!
-    startTime: BigInt! endTime: BigInt! nonce: BigInt! isActive: Boolean!
-    asset: AssetEntity
+    startTime: BigInt! endTime: BigInt! nonce: BigInt! isTerminated: Boolean!
+    
+    # Computed
+    isActive: Boolean!
+    
+    # Relations
+    asset: Asset
   }
   
   type SubscriptionPage { items: [Subscription!]! pageInfo: PageInfo! totalCount: Int! }
@@ -13,5 +19,6 @@ export const typeDefs = /* GraphQL */ `
 
   extend type Query {
     subscriptions(where: SubscriptionFilter, orderBy: String, orderDirection: String, limit: Int, offset: Int): SubscriptionPage!
+    activeSubscriptions(where: SubscriptionFilter, orderBy: String, orderDirection: String, limit: Int, offset: Int): SubscriptionPage!
   }
 `;

--- a/src/handlers/asset.ts
+++ b/src/handlers/asset.ts
@@ -30,7 +30,7 @@ ponder.on("Asset:SubscriptionAdded", async ({ event, context }) => {
     startTime: event.args.startTime,
     endTime: event.args.endTime,
     nonce: event.args.nonce,
-    isTerminated: false,
+    isRevoked: false,
   }).onConflictDoNothing();
 
   // 2. Log History
@@ -61,7 +61,7 @@ ponder.on("Asset:SubscriptionExtended", async ({ event, context }) => {
     .where(and(
       eq(Subscription.assetId, assetEntityId),
       eq(Subscription.subscriber, subscriber),
-      eq(Subscription.isTerminated, false),
+      eq(Subscription.isRevoked, false),
     ))
     .orderBy(desc(Subscription.nonce))
     .limit(1);
@@ -104,23 +104,28 @@ ponder.on("Asset:SubscriptionRevoked", async ({ event, context }) => {
   const subscriber = event.args.subscriber;
   const assetEntityId = getAssetEntityId(chainId, assetAddress);
 
-  // 1. Update State: terminate ALL non-terminated nonces for this subscriber
-  // Mirrors contract: active nonces are truncated, future nonces are removed
+  // 1. Update State: mirrors contract _removeSubscription logic exactly:
+  //    - Future nonces (startTime >= now): deleted on-chain → delete from DB so nonce can be reused
+  //    - Active nonces (startTime < now < endTime): truncated on-chain → set isRevoked + truncate endTime
   const rows = await context.db.sql
-    .select({ id: Subscription.id })
+    .select({ id: Subscription.id, startTime: Subscription.startTime })
     .from(Subscription)
     .where(and(
       eq(Subscription.assetId, assetEntityId),
       eq(Subscription.subscriber, subscriber),
-      eq(Subscription.isTerminated, false),
+      eq(Subscription.isRevoked, false),
       gt(Subscription.endTime, event.block.timestamp),
     ));
 
   for (const row of rows) {
-    await context.db.update(Subscription, { id: row.id }).set({
-      isTerminated: true,
-      endTime: event.block.timestamp,
-    });
+    if (row.startTime >= event.block.timestamp) {
+      await context.db.delete(Subscription, { id: row.id });
+    } else {
+      await context.db.update(Subscription, { id: row.id }).set({
+        isRevoked: true,
+        endTime: event.block.timestamp,
+      });
+    }
   }
 
   // 2. Log History
@@ -140,22 +145,27 @@ ponder.on("Asset:SubscriptionCancelled", async ({ event, context }) => {
   const subscriber = event.args.subscriber;
   const assetEntityId = getAssetEntityId(chainId, assetAddress);
 
-  // 1. Update State: terminate ALL non-terminated nonces for this subscriber
+  // 1. Update State: mirrors contract _removeSubscription logic exactly:
+  //    - Future nonces (startTime >= now): deleted on-chain → delete from DB so nonce can be reused
+  //    - Active nonces (startTime < now < endTime): truncated on-chain → truncate endTime only (no isRevoked flag)
   const rows = await context.db.sql
-    .select({ id: Subscription.id })
+    .select({ id: Subscription.id, startTime: Subscription.startTime })
     .from(Subscription)
     .where(and(
       eq(Subscription.assetId, assetEntityId),
       eq(Subscription.subscriber, subscriber),
-      eq(Subscription.isTerminated, false),
+      eq(Subscription.isRevoked, false),
       gt(Subscription.endTime, event.block.timestamp),
     ));
 
   for (const row of rows) {
-    await context.db.update(Subscription, { id: row.id }).set({
-      isTerminated: true,
-      endTime: event.block.timestamp,
-    });
+    if (row.startTime >= event.block.timestamp) {
+      await context.db.delete(Subscription, { id: row.id });
+    } else {
+      await context.db.update(Subscription, { id: row.id }).set({
+        endTime: event.block.timestamp,
+      });
+    }
   }
 
   // 2. Log History

--- a/src/handlers/asset.ts
+++ b/src/handlers/asset.ts
@@ -1,4 +1,5 @@
 import { ponder } from "ponder:registry";
+import { eq, and, desc, gt } from "ponder";
 import {
   AssetEntity,
   Subscription,
@@ -17,26 +18,11 @@ ponder.on("Asset:SubscriptionAdded", async ({ event, context }) => {
   const assetAddress = event.log.address.toLowerCase();
   const subscriber = event.args.subscriber;
   const payer = event.args.payer.toLowerCase();
-
   const assetEntityId = getAssetEntityId(chainId, assetAddress);
-  const id = getSubscriptionId(chainId, assetAddress, subscriber);
 
-  // Fetch existing subscription to preserve continuity of startTime
-  const existingSub = await context.db.find(Subscription, { id });
-
-  let computedStartTime = event.args.startTime;
-
-  // When the contract creates a new nonce (terms changed mid-subscription),
-  // it sets startTime = previous subscription's endTime, chaining them seamlessly.
-  // We detect this and preserve the original startTime to show unbroken continuity.
-  // Pure extensions (same terms) are handled by SubscriptionExtended instead.
-  if (existingSub && existingSub.endTime === event.args.startTime) {
-    computedStartTime = existingSub.startTime;
-  }
-
-  // 1. Upsert Subscription
+  // 1. Insert per-nonce Subscription row (idempotent on re-index)
   await context.db.insert(Subscription).values({
-    id: id,
+    id: getSubscriptionId(chainId, assetAddress, subscriber, event.args.nonce),
     chainId: chainId,
     assetId: assetEntityId,
     subscriber: subscriber,
@@ -44,14 +30,8 @@ ponder.on("Asset:SubscriptionAdded", async ({ event, context }) => {
     startTime: event.args.startTime,
     endTime: event.args.endTime,
     nonce: event.args.nonce,
-    isActive: true,
-  }).onConflictDoUpdate({
-    startTime: computedStartTime,
-    endTime: event.args.endTime,
-    nonce: event.args.nonce,
-    payer: payer,
-    isActive: true,
-  });
+    isTerminated: false,
+  }).onConflictDoNothing();
 
   // 2. Log History
   await context.db.insert(Asset_SubscriptionAdded).values({
@@ -72,11 +52,26 @@ ponder.on("Asset:SubscriptionExtended", async ({ event, context }) => {
   const chainId = context.chain?.id as number;
   const assetAddress = event.log.address.toLowerCase();
   const subscriber = event.args.subscriber;
+  const assetEntityId = getAssetEntityId(chainId, assetAddress);
 
-  // 1. Update State: extend the subscription end time
-  await context.db.update(Subscription, { id: getSubscriptionId(chainId, assetAddress, subscriber) }).set({
-    endTime: event.args.endTime,
-  });
+  // SubscriptionExtended has no nonce in the event — find the highest active nonce row
+  const rows = await context.db.sql
+    .select({ id: Subscription.id })
+    .from(Subscription)
+    .where(and(
+      eq(Subscription.assetId, assetEntityId),
+      eq(Subscription.subscriber, subscriber),
+      eq(Subscription.isTerminated, false),
+    ))
+    .orderBy(desc(Subscription.nonce))
+    .limit(1);
+
+  // 1. Update State: extend the end time of the latest active nonce
+  if (rows.length > 0) {
+    await context.db.update(Subscription, { id: rows[0]!.id }).set({
+      endTime: event.args.endTime,
+    });
+  }
 
   // 2. Log History
   await context.db.insert(Asset_SubscriptionExtended).values({
@@ -107,11 +102,26 @@ ponder.on("Asset:SubscriptionRevoked", async ({ event, context }) => {
   const chainId = context.chain?.id as number;
   const assetAddress = event.log.address.toLowerCase();
   const subscriber = event.args.subscriber;
+  const assetEntityId = getAssetEntityId(chainId, assetAddress);
 
-  // 1. Update State: mark as inactive
-  await context.db.update(Subscription, { id: getSubscriptionId(chainId, assetAddress, subscriber) }).set({
-    isActive: false,
-  });
+  // 1. Update State: terminate ALL non-terminated nonces for this subscriber
+  // Mirrors contract: active nonces are truncated, future nonces are removed
+  const rows = await context.db.sql
+    .select({ id: Subscription.id })
+    .from(Subscription)
+    .where(and(
+      eq(Subscription.assetId, assetEntityId),
+      eq(Subscription.subscriber, subscriber),
+      eq(Subscription.isTerminated, false),
+      gt(Subscription.endTime, event.block.timestamp),
+    ));
+
+  for (const row of rows) {
+    await context.db.update(Subscription, { id: row.id }).set({
+      isTerminated: true,
+      endTime: event.block.timestamp,
+    });
+  }
 
   // 2. Log History
   await context.db.insert(Asset_SubscriptionRevoked).values({
@@ -128,11 +138,25 @@ ponder.on("Asset:SubscriptionCancelled", async ({ event, context }) => {
   const chainId = context.chain?.id as number;
   const assetAddress = event.log.address.toLowerCase();
   const subscriber = event.args.subscriber;
+  const assetEntityId = getAssetEntityId(chainId, assetAddress);
 
-  // 1. Update State: mark as inactive
-  await context.db.update(Subscription, { id: getSubscriptionId(chainId, assetAddress, subscriber) }).set({
-    isActive: false,
-  });
+  // 1. Update State: terminate ALL non-terminated nonces for this subscriber
+  const rows = await context.db.sql
+    .select({ id: Subscription.id })
+    .from(Subscription)
+    .where(and(
+      eq(Subscription.assetId, assetEntityId),
+      eq(Subscription.subscriber, subscriber),
+      eq(Subscription.isTerminated, false),
+      gt(Subscription.endTime, event.block.timestamp),
+    ));
+
+  for (const row of rows) {
+    await context.db.update(Subscription, { id: row.id }).set({
+      isTerminated: true,
+      endTime: event.block.timestamp,
+    });
+  }
 
   // 2. Log History
   await context.db.insert(Asset_SubscriptionCancelled).values({

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -10,6 +10,6 @@ export const getAssetEntityId = (chainId: number, assetAddress: string) => {
   return `${chainId}_${assetAddress.toLowerCase()}`;
 };
 
-export const getSubscriptionId = (chainId: number, assetAddress: string, subscriber: string) => {
-  return `${chainId}_${assetAddress.toLowerCase()}_${subscriber}`;
+export const getSubscriptionId = (chainId: number, assetAddress: string, subscriber: string, nonce: bigint) => {
+  return `${chainId}_${assetAddress.toLowerCase()}_${subscriber}_${nonce}`;
 };


### PR DESCRIPTION
## ⚠️ Breaking Changes

This PR is **not backward compatible**. Clients using the `graphql`, `/v2/graphql` API
must update their queries before upgrading.

The `Subscription` table model has changed from **one row per subscriber** to **one row per subscriber-nonce**. Existing indexed data is incompatible and must be wiped and re-indexed from block 0.

### Why

The previous model upserted a single row per `(asset, subscriber)`, which broke when a subscriber re-subscribed with different terms (price, payer, or fee share) while still active. The contract issues a new nonce in this case — the old indexer silently lost the previous nonce's data. Revoke and cancel also iterate all non-expired nonces in the contract, which the
single-row model couldn't replicate.

### What changed

**Subscription table** — `id` format: `chainId_assetAddress_subscriber_nonce`
- Each nonce is an independent row
- `SubscriptionExtended` (no nonce in the event) finds the highest active
  nonce via raw Drizzle and updates its `endTime`
- Revoke/cancel terminates all non-expired nonces (`endTime > block.timestamp`)
- Added `startTime`, `endTime`, `nonce` indexes

**`isActive` computed field**
- Resolved at query time: `!isRevoked && startTime <= now && now < endTime`

**`activeSubscriptions` query**
- Available as a top-level query and as a field on `Asset`
- Filters at DB level so pagination and `totalCount` are accurate

**GraphQL renames** (non-breaking relative to v1 autogenerated API)
- `AssetEntity` → `Asset`, `assetEntitys` → `assets`
- `RegistryEntity` → `Registry`, `registryEntitys` → `registries`

### Impact on existing clients
- **Clients expecting a single subscription per subscriber will break.** Query results now return one row per nonce — clients must handle a list and select the relevant nonce (e.g. highest nonce, or filter by isActive).
- **`isActive` stored field is gone** — replaced by `isRevoked` (inverted boolean: true = explicitly revoked). The v2 API exposes `isActive` as a computed field calculated at query time from startTime, endTime, and isRevoked.


Closes #24 #28 