### PR TITLE
chore(ci): add deployment sync drift check

### DIFF
--- a/.github/workflows/deployment-sync-check.yml
+++ b/.github/workflows/deployment-sync-check.yml
@@ -1,0 +1,43 @@
+name: Deployment Sync Check
+
+on:
+  pull_request:
+    branches: [master]
+    paths:
+      - "open-creator-rails"
+      - "config/deployments/**"
+      - "scripts/sync-deployments.js"
+
+jobs:
+  deployment-sync:
+    name: Check deployments are in sync
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Sync deployments
+        run: node scripts/sync-deployments.js
+
+      - name: Check for drift
+        run: |
+          if ! git diff --exit-code config/deployments/; then
+            echo ""
+            echo "❌ Deployment files are out of sync with the submodule."
+            echo ""
+            echo "Run this locally and commit the result:"
+            echo "  node scripts/sync-deployments.js"
+            exit 1
+          fi
+          echo "✅ Deployments are in sync."

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "lint": "eslint . --ext .ts",
     "typecheck": "tsc",
     "contracts:build": "cd open-creator-rails && forge build",
-    "sync": "node scripts/sync-abis.js"
+    "sync": "pnpm contracts:build && node scripts/sync-abis.js",
+    "sync:deployments": "node scripts/sync-deployments.js"
   },
   "dependencies": {
     "abitype": "^1.2.4",


### PR DESCRIPTION
## Summary

- New CI workflow `deployment-sync-check.yml` runs on PRs touching the `open-creator-rails` submodule, `config/deployments/`, or `scripts/sync-deployments.js`. It regenerates deployment files from the submodule and fails if the working tree drifts — forcing contributors to re-run `sync-deployments.js` whenever the submodule is bumped.
- `package.json`: `sync` now runs `contracts:build` before `sync-abis.js` so ABIs are always generated from a fresh build. New `sync:deployments` script wraps `sync-deployments.js`.