### PR TITLE
feat(indexer): index claimedAtTimestamp/Nonce on claimed events

### DIFF
--- a/ponder.schema.ts
+++ b/ponder.schema.ts
@@ -82,11 +82,13 @@ export const assetEntityRelations = relations(AssetEntity, ({ one, many }) => ({
   subscriptions: many(Subscription),
 }));
 
-export const subscriptionRelations = relations(Subscription, ({ one }) => ({
+export const subscriptionRelations = relations(Subscription, ({ one, many }) => ({
   asset: one(AssetEntity, {
     fields: [Subscription.assetId],
     references: [AssetEntity.id],
   }),
+  creatorFeeClaims: many(Asset_CreatorFeeClaimed),
+  registryFeeClaims: many(AssetRegistry_RegistryFeeClaimed),
 }));
 
 // --- Events (Immutable History) ---
@@ -205,10 +207,13 @@ export const Asset_SubscriptionExtended = onchainTable("asset_subscription_exten
 }));
 
 export const Asset_CreatorFeeClaimed = onchainTable("asset_creator_fee_claimed", (t) => ({
-  id: t.text().primaryKey(),   // Composite: `${chainId}-${event.transaction.hash}-${event.log.logIndex}`
+  id: t.text().primaryKey(),       // Composite: `${chainId}-${event.transaction.hash}-${event.log.logIndex}`
   chainId: t.integer().notNull(),
   subscriber: t.text().notNull(),
   amount: t.bigint().notNull(),
+  claimedAtTimestamp: t.bigint().notNull(), // Subscription block timestamp at claim, indexed on-chain
+  claimedAtNonce: t.bigint().notNull(),     // Subscription nonce the claim applies to
+  subscriptionId: t.text(),                 // FK → Subscription.id; null if matching subscription row was deleted
   assetAddress: t.text().notNull(),
   blockNumber: t.bigint().notNull(),
   blockTimestamp: t.bigint().notNull(),
@@ -216,6 +221,33 @@ export const Asset_CreatorFeeClaimed = onchainTable("asset_creator_fee_claimed",
   chainIdIdx: index().on(table.chainId),
   subscriberIdx: index().on(table.subscriber),
   assetAddressIdx: index().on(table.assetAddress),
+  claimedAtNonceIdx: index().on(table.claimedAtNonce),
+  subscriptionIdIdx: index().on(table.subscriptionId),
+}));
+
+// Per-claim event from the Registry contract. Distinct from
+// AssetRegistry_RegistryFeeClaimedBatch (aggregated summary across subscribers).
+export const AssetRegistry_RegistryFeeClaimed = onchainTable("asset_registry_registry_fee_claimed", (t) => ({
+  id: t.text().primaryKey(),                // Composite: `${chainId}-${event.transaction.hash}-${event.log.logIndex}`
+  chainId: t.integer().notNull(),
+  assetId: t.text().notNull(),              // bytes32 asset id from the event topic
+  assetEntityId: t.text(),                  // FK → AssetEntity.id (`${chainId}_${assetAddress}`); null if AssetEntity row missing
+  subscriber: t.text().notNull(),
+  amount: t.bigint().notNull(),
+  claimedAtTimestamp: t.bigint().notNull(),
+  claimedAtNonce: t.bigint().notNull(),
+  subscriptionId: t.text(),                 // FK → Subscription.id; null if matching subscription row was deleted
+  registryAddress: t.text().notNull(),
+  blockNumber: t.bigint().notNull(),
+  blockTimestamp: t.bigint().notNull(),
+}), (table) => ({
+  chainIdIdx: index().on(table.chainId),
+  assetIdIdx: index().on(table.assetId),
+  assetEntityIdIdx: index().on(table.assetEntityId),
+  subscriberIdx: index().on(table.subscriber),
+  subscriptionIdIdx: index().on(table.subscriptionId),
+  registryAddressIdx: index().on(table.registryAddress),
+  claimedAtNonceIdx: index().on(table.claimedAtNonce),
 }));
 
 export const Asset_SubscriptionPriceUpdated = onchainTable("asset_subscription_price_updated", (t) => ({
@@ -286,4 +318,24 @@ export const Asset_OwnershipTransferred = onchainTable("asset_ownership_transfer
   previousOwnerIdx: index().on(table.previousOwner),
   newOwnerIdx: index().on(table.newOwner),
   assetAddressIdx: index().on(table.assetAddress),
+}));
+
+// Claim-event relations live at the bottom because they reference event
+// tables declared after the mutable-state relations block.
+export const assetCreatorFeeClaimedRelations = relations(Asset_CreatorFeeClaimed, ({ one }) => ({
+  subscription: one(Subscription, {
+    fields: [Asset_CreatorFeeClaimed.subscriptionId],
+    references: [Subscription.id],
+  }),
+}));
+
+export const assetRegistryRegistryFeeClaimedRelations = relations(AssetRegistry_RegistryFeeClaimed, ({ one }) => ({
+  asset: one(AssetEntity, {
+    fields: [AssetRegistry_RegistryFeeClaimed.assetEntityId],
+    references: [AssetEntity.id],
+  }),
+  subscription: one(Subscription, {
+    fields: [AssetRegistry_RegistryFeeClaimed.subscriptionId],
+    references: [Subscription.id],
+  }),
 }));

--- a/scripts/seed-local.sh
+++ b/scripts/seed-local.sh
@@ -195,6 +195,32 @@ echo "  Re-subscribing (contract emits SubscriptionRenewed nonce=1)..."
 ./scripts/subscribe.sh 0 "local_asset_7" "sub1_asset7" $SUB1_ADDR 3600 $SUB1_PK > /dev/null
 echo "  Sub1 re-subscribed to asset_7 (nonce 1 cleanly re-inserted in DB)"
 
+# ── Scenario: Creator + Registry fee claims ──────────────────────────────────
+# Exercises Asset.CreatorFeeClaimed and AssetRegistry.RegistryFeeClaimed so the
+# indexer's claim handlers (and their subscriptionId FK derivation) have live
+# events to consume.
+echo ""
+echo "=== Scenario: Fee Claims ==="
+
+echo "  Sub1 -> asset_8 (10m subscription)"
+./scripts/subscribe.sh 0 "local_asset_8" $SUB1_ID $SUB1_ADDR 600 $SUB1_PK > /dev/null
+
+# Advance Anvil time so the subscription accrues several periods worth of fees
+# before claiming. Without this, claimable would round down to ~0.
+cast rpc evm_increaseTime 300 --rpc-url $RPC_URL > /dev/null
+cast rpc evm_mine --rpc-url $RPC_URL > /dev/null
+
+ASSET8_ADDR=$(asset_addr "local_asset_8")
+ASSET8_ID=$(cast keccak "local_asset_8")
+
+echo "  Asset owner claims creator fee (-> CreatorFeeClaimed)"
+cast send $ASSET8_ADDR "claimCreatorFee(bytes32)" $SUB1_HASH \
+  --rpc-url $RPC_URL --private-key $PRIVATE_KEY > /dev/null
+
+echo "  Registry owner claims registry fee (-> RegistryFeeClaimed)"
+cast send $REGISTRY_ADDR "claimRegistryFee(bytes32,bytes32)" $ASSET8_ID $SUB1_HASH \
+  --rpc-url $RPC_URL --private-key $PRIVATE_KEY > /dev/null
+
 echo ""
 echo "Local seeding complete!"
 echo "  - asset_1: 2 active subscribers, Sub1 extended"
@@ -204,3 +230,4 @@ echo "  - asset_4: Sub1 with price-change nonce chain"
 echo "  - asset_5: Sub1 revoked with a future nonce deleted"
 echo "  - asset_6: Sub2 cancelled with a future nonce deleted"
 echo "  - asset_7: Sub1 active+future cancelled then re-subscribed (nonce 1 re-inserted)"
+echo "  - asset_8: Sub1 subscribed, time advanced 5m, creator+registry fees claimed"

--- a/src/api/asset/resolvers.ts
+++ b/src/api/asset/resolvers.ts
@@ -21,4 +21,8 @@ export const resolvers = {
     activeSubscriptions: (parent: any, a: any) =>
       queryList(schema.Subscription, { ...a.where, assetId: parent.id }, a.orderBy, a.orderDirection, a.limit, a.offset, activeSubscriptionConditions()),
   },
+
+  Asset_CreatorFeeClaimed: {
+    subscription: (parent: any) => parent.subscriptionId ? byId(schema.Subscription, parent.subscriptionId) : null,
+  },
 };

--- a/src/api/asset/typeDefs.ts
+++ b/src/api/asset/typeDefs.ts
@@ -40,11 +40,16 @@ export const typeDefs = /* GraphQL */ `
   type Asset_CreatorFeeClaimed {
     # Stored Fields
     id: String! chainId: Int! subscriber: String! amount: BigInt!
+    claimedAtTimestamp: BigInt! claimedAtNonce: BigInt! subscriptionId: String
     assetAddress: Address! blockNumber: BigInt! blockTimestamp: BigInt!
+
+    # Relations
+    subscription: Subscription
   }
   type Asset_CreatorFeeClaimedPage { items: [Asset_CreatorFeeClaimed!]! pageInfo: PageInfo! totalCount: Int! }
   input Asset_CreatorFeeClaimedFilter {
     id: String  chainId: Int  subscriber: String  assetAddress: Address
+    claimedAtNonce: BigInt  subscriptionId: String
   }
 
   type Asset_SubscriptionPriceUpdated {

--- a/src/api/registry/resolvers.ts
+++ b/src/api/registry/resolvers.ts
@@ -9,10 +9,16 @@ export const resolvers = {
     assetRegistry_OwnershipTransferreds: (_: any, a: any) => queryList(schema.AssetRegistry_OwnershipTransferred, a.where, a.orderBy, a.orderDirection, a.limit, a.offset),
     assetRegistry_RegistryFeeShareUpdateds: (_: any, a: any) => queryList(schema.AssetRegistry_RegistryFeeShareUpdated, a.where, a.orderBy, a.orderDirection, a.limit, a.offset),
     assetRegistry_RegistryFeeClaimedBatchs: (_: any, a: any) => queryList(schema.AssetRegistry_RegistryFeeClaimedBatch, a.where, a.orderBy, a.orderDirection, a.limit, a.offset),
+    assetRegistry_RegistryFeeClaimeds:      (_: any, a: any) => queryList(schema.AssetRegistry_RegistryFeeClaimed, a.where, a.orderBy, a.orderDirection, a.limit, a.offset),
   },
 
   Registry: {
     assets: (parent: any, a: any) =>
       queryList(schema.AssetEntity, { ...a.where, registryId: parent.id }, a.orderBy, a.orderDirection, a.limit, a.offset),
+  },
+
+  AssetRegistry_RegistryFeeClaimed: {
+    asset:        (parent: any) => parent.assetEntityId ? byId(schema.AssetEntity, parent.assetEntityId) : null,
+    subscription: (parent: any) => parent.subscriptionId ? byId(schema.Subscription, parent.subscriptionId) : null,
   },
 };

--- a/src/api/registry/typeDefs.ts
+++ b/src/api/registry/typeDefs.ts
@@ -52,6 +52,24 @@ export const typeDefs = /* GraphQL */ `
     id: String  chainId: Int  assetId: String  registryAddress: Address
   }
 
+  type AssetRegistry_RegistryFeeClaimed {
+    # Stored Fields
+    id: String! chainId: Int! assetId: String! assetEntityId: String
+    subscriber: String! amount: BigInt!
+    claimedAtTimestamp: BigInt! claimedAtNonce: BigInt! subscriptionId: String
+    registryAddress: String! blockNumber: BigInt! blockTimestamp: BigInt!
+
+    # Relations
+    asset: Asset
+    subscription: Subscription
+  }
+  type AssetRegistry_RegistryFeeClaimedPage { items: [AssetRegistry_RegistryFeeClaimed!]! pageInfo: PageInfo! totalCount: Int! }
+  input AssetRegistry_RegistryFeeClaimedFilter {
+    id: String  chainId: Int  assetId: String  assetEntityId: String
+    subscriber: String  registryAddress: Address
+    claimedAtNonce: BigInt  subscriptionId: String
+  }
+
   extend type Query {
     registries(where: RegistryFilter, orderBy: String, orderDirection: String, limit: Int, offset: Int): RegistryPage!
 
@@ -62,5 +80,7 @@ export const typeDefs = /* GraphQL */ `
     assetRegistry_RegistryFeeShareUpdateds(where: AssetRegistry_RegistryFeeShareUpdatedFilter, orderBy: String, orderDirection: String, limit: Int, offset: Int): AssetRegistry_RegistryFeeShareUpdatedPage!
 
     assetRegistry_RegistryFeeClaimedBatchs(where: AssetRegistry_RegistryFeeClaimedBatchFilter, orderBy: String, orderDirection: String, limit: Int, offset: Int): AssetRegistry_RegistryFeeClaimedBatchPage!
+
+    assetRegistry_RegistryFeeClaimeds(where: AssetRegistry_RegistryFeeClaimedFilter, orderBy: String, orderDirection: String, limit: Int, offset: Int): AssetRegistry_RegistryFeeClaimedPage!
   }
 `;

--- a/src/handlers/asset.ts
+++ b/src/handlers/asset.ts
@@ -129,12 +129,30 @@ ponder.on("Asset:SubscriptionExtended", async ({ event, context }) => {
 
 ponder.on("Asset:CreatorFeeClaimed", async ({ event, context }) => {
   const chainId = context.chain?.id as number;
+  const assetAddress = event.log.address.toLowerCase();
+  const subscriber = event.args.subscriber;
+  const claimedAtNonce = event.args.claimedAtNonce;
+
+  // FK is best-effort: rows can be hard-deleted on revoke of future nonces
+  // or SubscriptionRemoved, in which case we keep the claim row but leave
+  // subscriptionId null instead of failing the insert.
+  const subscriptionId = getSubscriptionId(chainId, assetAddress, subscriber, claimedAtNonce);
+  const subscriptionRows = await context.db.sql
+    .select({ id: Subscription.id })
+    .from(Subscription)
+    .where(eq(Subscription.id, subscriptionId))
+    .limit(1);
+  const linkedSubscriptionId = subscriptionRows.length > 0 ? subscriptionId : null;
+
   await context.db.insert(Asset_CreatorFeeClaimed).values({
     id: getEventId(event, chainId),
     chainId: chainId,
-    subscriber: event.args.subscriber,
+    subscriber: subscriber,
     amount: event.args.amount,
-    assetAddress: event.log.address.toLowerCase(),
+    claimedAtTimestamp: event.args.claimedAtTimestamp,
+    claimedAtNonce: claimedAtNonce,
+    subscriptionId: linkedSubscriptionId,
+    assetAddress: assetAddress,
     blockNumber: event.block.number,
     blockTimestamp: event.block.timestamp,
   });

--- a/src/handlers/registry.ts
+++ b/src/handlers/registry.ts
@@ -1,13 +1,16 @@
 import { ponder } from "ponder:registry";
+import { and, eq } from "ponder";
 import {
   RegistryEntity,
   AssetEntity,
+  Subscription,
   AssetRegistry_AssetCreated,
   AssetRegistry_OwnershipTransferred,
   AssetRegistry_RegistryFeeShareUpdated,
   AssetRegistry_RegistryFeeClaimedBatch,
+  AssetRegistry_RegistryFeeClaimed,
 } from "../../ponder.schema";
-import { getEventId, getAssetEntityId, getRegistryEntityId } from "../utils";
+import { getEventId, getAssetEntityId, getRegistryEntityId, getSubscriptionId } from "../utils";
 
 ponder.on("AssetRegistry:AssetCreated", async ({ event, context }) => {
   const chainId = context.chain?.id as number;
@@ -106,6 +109,52 @@ ponder.on("AssetRegistry:RegistryFeeClaimedBatch", async ({ event, context }) =>
     chainId: chainId,
     assetId: event.args.assetId,
     totalAmount: event.args.totalAmount,
+    registryAddress: event.log.address.toLowerCase(),
+    blockNumber: event.block.number,
+    blockTimestamp: event.block.timestamp,
+  });
+});
+
+ponder.on("AssetRegistry:RegistryFeeClaimed", async ({ event, context }) => {
+  const chainId = context.chain?.id as number;
+  const assetId = event.args.assetId;
+  const subscriber = event.args.subscriber;
+  const claimedAtNonce = event.args.claimedAtNonce;
+
+  // The event indexes by assetId (bytes32), but the AssetEntity primary key is
+  // chain-scoped on address. Resolve the address by joining through AssetEntity.
+  const assetRows = await context.db.sql
+    .select({ id: AssetEntity.id, address: AssetEntity.address })
+    .from(AssetEntity)
+    .where(and(eq(AssetEntity.chainId, chainId), eq(AssetEntity.assetId, assetId)))
+    .limit(1);
+  const assetRow = assetRows[0];
+
+  // Subscription rows can be hard-deleted on future-nonce revoke / SubscriptionRemoved.
+  // FK is best-effort: persist the claim either way, leave subscriptionId null when no row.
+  let linkedSubscriptionId: string | null = null;
+  if (assetRow) {
+    const candidateId = getSubscriptionId(chainId, assetRow.address, subscriber, claimedAtNonce);
+    const subscriptionRows = await context.db.sql
+      .select({ id: Subscription.id })
+      .from(Subscription)
+      .where(eq(Subscription.id, candidateId))
+      .limit(1);
+    if (subscriptionRows.length > 0) {
+      linkedSubscriptionId = candidateId;
+    }
+  }
+
+  await context.db.insert(AssetRegistry_RegistryFeeClaimed).values({
+    id: getEventId(event, chainId),
+    chainId: chainId,
+    assetId: assetId,
+    assetEntityId: assetRow?.id ?? null,
+    subscriber: subscriber,
+    amount: event.args.amount,
+    claimedAtTimestamp: event.args.claimedAtTimestamp,
+    claimedAtNonce: claimedAtNonce,
+    subscriptionId: linkedSubscriptionId,
     registryAddress: event.log.address.toLowerCase(),
     blockNumber: event.block.number,
     blockTimestamp: event.block.timestamp,


### PR DESCRIPTION
## Summary

Index the two new claimed-event params introduced upstream (`claimedAtTimestamp`, `claimedAtNonce`) on both the `Asset.CreatorFeeClaimed` and `AssetRegistry.RegistryFeeClaimed` events, and link each claim row back to the `Subscription` nonce it was paid against.

Closes #45 