### PR TITLE
feat(indexer): claimable amount query with rollup

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ Raw event history for debugging and analytics:
 - `AssetRegistry_OwnershipTransferred`
 - `AssetRegistry_RegistryFeeShareUpdated`
 - `AssetRegistry_RegistryFeeClaimedBatch`
+- `AssetRegistry_RegistryFeeClaimed`
 - `Asset_SubscriptionAdded`
 - `Asset_SubscriptionExtended`
 - `Asset_SubscriptionPriceUpdated`
@@ -248,3 +249,113 @@ Raw event history for debugging and analytics:
 - `Asset_SubscriptionCancelled`
 - `Asset_CreatorFeeClaimed`
 - `Asset_OwnershipTransferred`
+
+### `SubscriberClaimable`
+One row per `(asset, subscriber)`. Denormalised state backing the `Asset.claimable(subscriber)` and `Asset.claimableTotal` GraphQL fields — see [Claimable Amounts](#claimable-amounts) below.
+
+- `id`: `${chainId}_${assetAddress}_${subscriber}`.
+- `creatorClaimedAtNonce` / `creatorClaimedAtTimestamp`: mirror the on-chain `creatorClaimedAtNonces[subscriber]` / `creatorClaimedAtTimestamps[subscriber]` pointers.
+- `registryClaimedAtNonce` / `registryClaimedAtTimestamp`: same for the registry-side pointers.
+- `creatorFee` / `registryFee`: accrued claimable amounts as of the last refresh.
+- `refreshedAtBlock` / `refreshedAtTimestamp`: when the row was last brought up to date. Exposed as `asOfBlock` / `asOfTimestamp` in the GraphQL response so consumers can reason about freshness.
+
+---
+
+## Claimable Amounts
+
+The `Asset.claimable(subscriber)` and `Asset.claimableTotal` GraphQL fields surface how much creator-side and registry-side fee is currently claimable on an asset. The math is a faithful TypeScript port of the contract's internal `_claimable()` ([Asset.sol](open-creator-rails/src/Asset.sol#L289)).
+
+### Why a rollup table
+
+Claimable amounts are a function of **`(subscription state, block.timestamp)`**. They grow over time even when no on-chain event fires — every period boundary that crosses adds newly-accrued fees to whichever side hasn't claimed past it.
+
+That property rules out two simpler designs:
+
+| Approach | Why it doesn't work |
+|---|---|
+| **Resolver-time compute** (math runs per GraphQL query, fetching subscriptions on demand) | Per-asset totals fan out to `O(N_subscribers)` round-trips per query. At 1000+ subscribers with remote-Postgres latency, response times measured in tens of seconds. Doesn't fit the indexer's "DB is the source of truth, queries are cheap" model. |
+| **Store `creatorFee` / `registryFee` directly, updated only in event handlers** | Numbers correct only at event boundaries; stale between events. For the 1-second local seed periods the value is wrong on the next block. For monthly Sepolia periods the value drifts for up to 30 days after each period boundary that crosses without an event firing. |
+
+The rollup approach splits the work:
+
+1. **Event-driven** — every subscription/claim event handler upserts the row's pointers and recomputes fees against `event.block.timestamp`. Captures all state changes exactly at the event.
+2. **Block-interval** — the `ClaimableRefresh` block source (declared in `ponder.config.ts`) fires a handler every N blocks that recomputes fees for every rollup row against the current block's timestamp. Catches the time-only updates that no event would trigger.
+
+GraphQL reads become O(1) PK lookups (per-subscriber) or one aggregate query (per-asset total).
+
+### Alternative design considered: cumulative totals
+
+A natural-looking simplification is to store **lifetime accruals** instead of per-side pointers:
+
+```
+SubscriberClaimable {
+  totalCreatorAccrued, totalRegistryAccrued,  // grow as periods elapse
+  totalCreatorClaimed, totalRegistryClaimed,  // sum of past claim event amounts
+}
+
+claimable = totalAccrued - totalClaimed
+```
+
+This makes claim-event handlers trivial — `totalClaimed += event.args.amount`. No subscription fetch, no per-side guards, no pointer arithmetic.
+
+It fails on fidelity due to **integer-division dust**. The contract truncates per claim:
+
+```solidity
+uint256 fee         = count * subscription.subscriptionPrice;
+uint256 registryFee = (fee * subscription.registryFeeShare) / 100;   // truncated
+```
+
+Truncation happens once per claim call, so `sum over claims { floor(claim_periods × price × share / 100) }` is generally **less than** `floor(total_periods × price × share / 100)`.
+
+Concrete example with `price = 10`, `share = 3`, `duration = 1`:
+
+| Claim pattern | Periods per claim | Contract pays per claim | Total paid (10 periods) |
+|---|---|---|---|
+| 1 claim covering 10 periods | 10 | `floor(10·10·3/100) = 3` | 3 |
+| 10 claims of 1 period each | 1 | `floor(1·10·3/100) = 0` | **0** |
+
+Both subscribers accrued the same 10 periods, but the second receives nothing on-chain because each per-period claim rounds to zero.
+
+The cumulative model's `totalAccrued` at 10 periods is `floor(10·10·3/100) = 3` in either pattern. So `claimable = totalAccrued − totalClaimed` would report **3** for the second subscriber, while the contract would pay them **0** on the next claim. The model **over-reports** by the per-claim dust accumulated over the subscription's lifetime — a UI built on it would tell users they can claim funds the contract refuses to release.
+
+The pointer model avoids this because the pointer (`claimedAtTimestamp`) records exactly where the contract's last truncation cut off. `floor((now − pointer) / duration) × price × share / 100` therefore matches what the contract would pay if claimed at this moment.
+
+**When does the dust actually matter?** Drift accumulates whenever `price × share / 100` is comparable to or smaller than `1` token. The current deployments span the spectrum:
+
+- `share = 80, price = 18` (local seed): per-period contribution `(1·18·80)/100 = 14`. No truncation, no drift.
+- `share = 30, price = 1` (Sepolia `asset_1`): per-period contribution `(1·1·30)/100 = 0`. High drift risk under frequent claims.
+- `share = 30, price = 1_000_000` (Sepolia `asset_2`): per-period contribution `300_000`. Negligible drift.
+
+The bottom line: the cumulative model is conceptually clean and would simplify the claim-event handler, but it can silently diverge from on-chain truth on low-share/low-price assets. The pointer model is more code but preserves contract fidelity for all parameter combinations.
+
+A reasonable follow-up is **storing `totalCreatorClaimed` / `totalRegistryClaimed` as additional columns alongside the pointers**, populated incrementally by the claim event handlers. The pointer stays the source of truth for live claimable; the totals are bookkeeping for owner-facing "lifetime earned / claimed" dashboards. That hybrid avoids the fidelity issue and gives the simpler claim handler for free, but it's deferred until there's a consumer asking for those numbers.
+
+### Refresh cost at scale
+
+The block-interval refresh iterates every `SubscriberClaimable` row on the chain via keyset pagination (500 rows per page). Each row's refresh issues ~4 sequential queries: asset metadata, current pointer state, subscription nonces, upsert.
+
+Approximate wall-clock per refresh fire (assuming ~10ms per round-trip on remote Postgres):
+
+| Subscribers (chain-wide) | Avg nonces per subscriber | Sequential queries | Wall-clock |
+|---|---|---|---|
+| 100 | 5 | ~400 | ~4 s |
+| 1,000 | 5 | ~4,000 | ~40 s |
+| 10,000 | 10 | ~40,000 | ~100 s |
+
+This work runs synchronously inside the indexing pipeline — on-chain events queue while the refresh is in flight. At the configured Sepolia interval (`7200` blocks ≈ 24h), even the 10k-subscriber case is a ~2-minute event-processing backlog once per day, which catches up within seconds afterward.
+
+Local development uses `interval: 1` (refresh fires every block). This is only viable because the seed produces a handful of rollup rows; with realistic subscriber counts it would slow Anvil to a crawl.
+
+### When to apply the next optimisation
+
+The current implementation is correctness-first, not throughput-tuned. The fan-out point is in `refreshAllSubscriberClaimable` ([src/handlers/claimable.ts](src/handlers/claimable.ts)): each rollup row triggers its own 4-query refresh.
+
+If subscriber counts grow past ~500 chain-wide and refresh lag becomes operationally visible.
+
+### Staleness semantics
+
+Every GraphQL response includes `asOfBlock` and `asOfTimestamp` fields reflecting when the underlying rollup row was last refreshed. Between refreshes, **on-chain claimable continues to grow** as periods elapse — the indexer's number is a lower bound on what the contract would actually pay out at chain head.
+
+For UI use cases that need exact on-chain numbers (e.g. "Click to claim X tokens"), the consumer should either:
+- Display `asOf*` alongside the number so users understand the staleness window, or
+- Fall back to an RPC `eth_call` against the contract's claim function with state override at the moment of UI commitment.

--- a/README.md
+++ b/README.md
@@ -330,6 +330,33 @@ The bottom line: the cumulative model is conceptually clean and would simplify t
 
 A reasonable follow-up is **storing `totalCreatorClaimed` / `totalRegistryClaimed` as additional columns alongside the pointers**, populated incrementally by the claim event handlers. The pointer stays the source of truth for live claimable; the totals are bookkeeping for owner-facing "lifetime earned / claimed" dashboards. That hybrid avoids the fidelity issue and gives the simpler claim handler for free, but it's deferred until there's a consumer asking for those numbers.
 
+### Alternative design considered: incremental calculation pointer
+
+A second natural-looking optimisation targets refresh cost: introduce a *separate* "calculation pointer" that advances on every refresh, independent of the claim pointer that moves only on real claim events:
+
+```
+SubscriberClaimable {
+  creatorClaimedAt*,  registryClaimedAt*,    // on-chain claim pointers (current)
+  creatorCalculatedAt*, registryCalculatedAt*,  // proposed: per-refresh cursor
+  creatorFee, registryFee,                   // accumulated across refreshes
+}
+```
+
+Refresh would iterate only from `calculatedAt*` → current state and **accumulate** the delta into the stored `creatorFee` / `registryFee`. Cost drops from `O(nonces since last claim)` to `O(new nonces since last refresh)` — usually 0 between renewals, occasionally 1. A claim event would reset the stored fee to 0 and re-align the calculation pointer to the new claim pointer.
+
+It fails on **the same integer-truncation dust** as the cumulative-totals model above. Solidity truncates `(fee × share) / 100` exactly once per claim call, so summing per-refresh-window truncations diverges from a single end-of-window truncation.
+
+Concrete example with `price = 1`, `share = 30`, `duration = 30 days`, monthly subscription claimed once at year-end:
+
+| Refresh cadence | count per window | Truncated fee per window | Sum across 12 windows |
+|---|---|---|---|
+| Daily refresh × 12 months | 1 | `floor(1·1·30/100) = 0` | **0** |
+| Contract's actual payout if claimed once at year-end | 12 | `floor(12·1·30/100) = 3` | **3** |
+
+The incremental approach would persistently under-report by 3 tokens for the full year — until a claim happens and resets, at which point the next cycle starts under-reporting again. The recompute-from-claim-pointer approach the indexer uses today wraps `floor()` once around the full unclaimed window and matches the contract exactly.
+
+Same sensitivity analysis as the cumulative model applies — drift bites when `price × share / 100` rounds to a small or zero per-period value. Sepolia `asset_1` (price=1, share=30) is exposed; high-priced assets are not.
+
 ### Refresh cost at scale
 
 The block-interval refresh iterates every `SubscriberClaimable` row on the chain via keyset pagination (500 rows per page). Each row's refresh issues ~4 sequential queries: asset metadata, current pointer state, subscription nonces, upsert.
@@ -350,7 +377,65 @@ Local development uses `interval: 1` (refresh fires every block). This is only v
 
 The current implementation is correctness-first, not throughput-tuned. The fan-out point is in `refreshAllSubscriberClaimable` ([src/handlers/claimable.ts](src/handlers/claimable.ts)): each rollup row triggers its own 4-query refresh.
 
-If subscriber counts grow past ~500 chain-wide and refresh lag becomes operationally visible.
+**Signal to act:** sustained refresh duration > 10s, observable in the indexer logs as `[ClaimableRefresh] chainId=… refreshed=N duration=Xms` (emitted on every block-interval fire). On Sepolia at the daily cadence, that corresponds to ~500+ active rollup rows.
+
+There are two distinct optimisations available, each addressing a different bottleneck:
+
+**Step 1 — Per-page batch fetches in `refreshAllSubscriberClaimable`.**
+
+Today each rollup row triggers its own 4 sequential queries (`asset` metadata, current pointer state, subscription nonces, upsert). Most of that is amortisable across a page of 500 rows:
+
+- 1 query per page fetching all relevant `AssetEntity.subscriptionDuration` values via `IN (...)`.
+- 1 query per page fetching all `Subscription` rows whose `(assetId, subscriber)` is in the page, ordered for in-memory grouping.
+- 1 bulk `INSERT … ON CONFLICT DO UPDATE` per page (Postgres supports up to ~65k parameters per statement — well above 500 rows × column count).
+
+Total round-trips drop from `O(N)` to `O(N / 500)` — roughly **10× faster** at 10k rows. No schema change, no math change, no fidelity impact. The `computeClaimable` helper stays exactly as it is; only the data-fetching shape around it shifts. ~80 lines of code in `refreshAllSubscriberClaimable`.
+
+Apply this first. It buys an order of magnitude with minimal risk.
+
+**Step 2 — Cache finalised per-nonce contributions on `SubscriberClaimable`.**
+
+Once Step 1 lands, the next bottleneck is per-row work inside the loop: `computeClaimable` walks every nonce since the last claim event for each subscriber. For an asset where the creator claims annually but subscribers renew monthly, that's ~12 nonces walked per subscriber per refresh.
+
+The fix is two extra columns on `SubscriberClaimable` — no new entity needed — caching the **running sum of per-nonce truncated contributions** for nonces that are no longer in-flight:
+
+```
+SubscriberClaimable {
+  ...existing pointers + refreshedAt*...
+  finalizedCreatorFee:  bigint   // sum of floor(count × price × (100-share) / 100) over finalised nonces
+  finalizedRegistryFee: bigint   // sum of floor(count × price × share / 100) over finalised nonces
+}
+```
+
+"Finalised" = the nonce is no longer accruing. A nonce is finalised when one of these fires:
+- `SubscriptionRenewed` — terms changed, the previous nonce is now closed.
+- `SubscriptionRevoked` / `SubscriptionCancelled` — the latest nonce's `endTime` was truncated.
+
+The handler logic stays bounded:
+
+| Event | Update |
+|---|---|
+| `SubscriptionAdded` | Initialise row with `finalized*Fee = 0`. New nonce starts in-flight. |
+| `SubscriptionRenewed` | Compute the previous nonce's truncated contribution `(count × price, then ÷ 100 once)` and add to the finalised totals. |
+| `SubscriptionExtended` | No-op for finalised totals — active nonce's `endTime` ceiling shifts, but the nonce isn't finalised. |
+| `SubscriptionRevoked` / `SubscriptionCancelled` | Same as `Renewed` — finalise the truncated nonce. |
+| `SubscriptionRemoved` | Delete the row. |
+| `CreatorFeeClaimed` | Reset `finalizedCreatorFee = 0` (the claim paid out everything finalised plus the in-flight partial); advance creator pointer. |
+| `RegistryFeeClaimed` | Same on the registry side. |
+
+Each block-interval refresh reads **one** `Subscription` row — the active nonce — computes the partial contribution against the current `asOf`, and returns `finalizedFee + activePartial` per side. Past nonces never get fetched. The refresh cost per (asset, subscriber) drops from `O(nonces_since_last_claim)` to `O(1)`.
+
+**Why this preserves contract fidelity:**
+
+1. Each `floor()` happens exactly once per nonce — at the finalisation event — mirroring `_claimable`'s per-iteration `floor((fee × share) / 100)`. No accumulated drift across refresh windows.
+2. Past nonces never get retroactively modified in the contract (`Revoked`/`Cancelled` only touch the latest nonce's `endTime`), so the running sums are monotonic until a claim resets them. No cache-invalidation logic needed.
+3. The active nonce's partial is recomputed fresh on every refresh — no aggregation, no drift.
+
+**Combined with Step 1**, refresh becomes ~3 queries per 500-row page (asset metadata IN-clause, latest-active-nonce IN-clause, bulk upsert), regardless of how many subscribers each asset has or how many nonces each subscriber has accumulated.
+
+This is a non-trivial change — two new columns plus ~6 handler touchpoints to keep the invariant intact (`SubscriptionAdded` / `Renewed` / `Extended` / `Revoked` / `Cancelled` / `Removed` plus the two claim events) — but no schema entity, no side-table invalidation, and the same single-truncation-per-nonce guarantee the current design has.
+
+**What NOT to do:** the [Alternative design considered: incremental calculation pointer](#alternative-design-considered-incremental-calculation-pointer) approach looks like it solves the same problem more cheaply, but it introduces silent drift on low `price × share / 100` assets. Don't reach for that as a shortcut.
 
 ### Staleness semantics
 

--- a/ponder.config.ts
+++ b/ponder.config.ts
@@ -76,4 +76,24 @@ export default createConfig({
       }
     }
   },
+  blocks: {
+    // Periodic refresh of the SubscriberClaimable rollup. Catches the "time
+    // has passed but no event fired" case — fees accrue at every period
+    // boundary even without on-chain activity. Event handlers keep the rollup
+    // accurate for state changes; this fills the time-only gaps.
+    //
+    // Interval is per-chain: Sepolia = 7200 blocks (~24h at 12s blocks); local
+    // = 1 (every block). Local fires often because Anvil produces blocks only
+    // when txs are sent, so the seed naturally triggers refreshes.
+    ClaimableRefresh: {
+      chain: {
+        ...(process.env.PONDER_RPC_URL_11155111 ? {
+          sepolia: { startBlock: 10299077, interval: 7200 },
+        } : {}),
+        ...(process.env.PONDER_RPC_URL_31337 ? {
+          local: { startBlock: 0, interval: 1 },
+        } : {}),
+      },
+    },
+  },
 });

--- a/ponder.schema.ts
+++ b/ponder.schema.ts
@@ -68,6 +68,42 @@ export const Subscription = onchainTable("subscription", (t) => ({
   endTimeIdx: index().on(table.endTime),
 }));
 
+// One row per (asset, subscriber). Maintains a denormalized snapshot of the
+// claimable fee numbers + the on-chain "claimed up to" pointers, so the
+// `Asset.claimable(subscriber)` / `Asset.claimableTotal` GraphQL fields can be
+// resolved with O(1) reads instead of recomputing per-nonce math on every
+// query.
+//
+// Maintenance strategy (see src/handlers/claimable.ts):
+//   - Event-driven: every Asset subscription/claim event upserts this row with
+//     fees recomputed as of event.block.timestamp. Captures all state changes
+//     and the immediate-after-claim "0 claimable" state.
+//   - Block-interval: a periodic refresh handler (configured in ponder.config.ts)
+//     recomputes fees for every row using the latest block timestamp. Catches
+//     the case where time passes but no event fires (fees accrue when periods
+//     elapse, with or without on-chain activity).
+//
+// Staleness: at most one refresh interval. `refreshedAt*` fields surface that
+// freshness to API consumers via the ClaimableAmount.asOf* GraphQL fields.
+export const SubscriberClaimable = onchainTable("subscriber_claimable", (t) => ({
+  id: t.text().primaryKey(),                        // Composite: `${chainId}_${assetAddress}_${subscriber}` (== `${assetEntityId}_${subscriber}`)
+  chainId: t.integer().notNull(),
+  assetEntityId: t.text().notNull(),                // FK → AssetEntity.id
+  subscriber: t.text().notNull(),                   // bytes32 subscriber identity hash
+  creatorClaimedAtNonce: t.bigint().notNull(),      // mirrors on-chain creatorClaimedAtNonces[subscriber]
+  creatorClaimedAtTimestamp: t.bigint().notNull(),  // mirrors on-chain creatorClaimedAtTimestamps[subscriber]
+  registryClaimedAtNonce: t.bigint().notNull(),     // mirrors on-chain registryClaimedAtNonces[subscriber]
+  registryClaimedAtTimestamp: t.bigint().notNull(), // mirrors on-chain registryClaimedAtTimestamps[subscriber]
+  creatorFee: t.bigint().notNull(),                 // accrued creator-side claimable as of refreshedAt*
+  registryFee: t.bigint().notNull(),                // accrued registry-side claimable as of refreshedAt*
+  refreshedAtBlock: t.bigint().notNull(),
+  refreshedAtTimestamp: t.bigint().notNull(),
+}), (table) => ({
+  chainIdIdx: index().on(table.chainId),
+  assetEntityIdIdx: index().on(table.assetEntityId),
+  subscriberIdx: index().on(table.subscriber),
+}));
+
 // --- Relations ---
 
 export const registryEntityRelations = relations(RegistryEntity, ({ many }) => ({

--- a/scripts/seed-local.sh
+++ b/scripts/seed-local.sh
@@ -53,7 +53,7 @@ TOKEN_ADDR=$(jq -r '.["31337"]' deployments/token_addresses.json)
 LOCAL_SUBSCRIPTION_DURATION=1
 
 echo "3. Creating Assets..."
-for i in {1..8}; do
+for i in {1..9}; do
   price=$((i * 2))
   ./scripts/createAsset.sh 0 "local_asset_$i" $price $LOCAL_SUBSCRIPTION_DURATION $TOKEN_ADDR $DEPLOYER_ADDR $PRIVATE_KEY > /dev/null
   echo "  local_asset_$i (price: $price tokens/period, duration: ${LOCAL_SUBSCRIPTION_DURATION}s)"
@@ -221,6 +221,37 @@ echo "  Registry owner claims registry fee (-> RegistryFeeClaimed)"
 cast send $REGISTRY_ADDR "claimRegistryFee(bytes32,bytes32)" $ASSET8_ID $SUB1_HASH \
   --rpc-url $RPC_URL --private-key $PRIVATE_KEY > /dev/null
 
+# ── Scenario: Claimable amount visibility (no claim) ─────────────────────────
+# Establishes a known-state subscription whose claimable value can be queried
+# via /v2/graphql after the indexer catches up. Verifies the indexed
+# claimable resolver against on-chain truth without actually claiming —
+# leaves both fee pots intact so the consumer can read live numbers.
+echo ""
+echo "=== Scenario: Claimable (no claim) ==="
+
+echo "  Sub1 -> asset_9 (2000 periods)"
+./scripts/subscribe.sh 0 "local_asset_9" $SUB1_ID $SUB1_ADDR 2000 $SUB1_PK > /dev/null
+
+# Warp Anvil forward so exactly 1000 periods of fees have accrued, then mine
+# a block to commit the new timestamp. evm_mine is called twice to make sure
+# the post-warp block is the latest indexed head when Ponder catches up.
+cast rpc evm_increaseTime 1000 --rpc-url $RPC_URL > /dev/null
+cast rpc evm_mine --rpc-url $RPC_URL > /dev/null
+cast rpc evm_mine --rpc-url $RPC_URL > /dev/null
+
+ASSET9_PRICE=18                                  # i=9, price = i*2
+ASSET9_REGSHARE=80                               # first arg to deployRegistry.sh
+EXPECTED_FEE=$((1000 * ASSET9_PRICE))            # 18000
+EXPECTED_REG=$((EXPECTED_FEE * ASSET9_REGSHARE / 100))  # 14400
+EXPECTED_CRE=$((EXPECTED_FEE - EXPECTED_REG))    # 3600
+
+echo "  +1000s elapsed without claim. Expected claimable for Sub1 on asset_9:"
+echo "    creatorFee  = $EXPECTED_CRE"
+echo "    registryFee = $EXPECTED_REG"
+echo "  Verify via /v2/graphql once Ponder catches up:"
+echo "    { assets(where: { assetId: \"local_asset_9\" }) {"
+echo "        items { claimable(subscriber: \"$SUB1_HASH\") { creatorFee registryFee asOfBlock } } } }"
+
 echo ""
 echo "Local seeding complete!"
 echo "  - asset_1: 2 active subscribers, Sub1 extended"
@@ -231,3 +262,4 @@ echo "  - asset_5: Sub1 revoked with a future nonce deleted"
 echo "  - asset_6: Sub2 cancelled with a future nonce deleted"
 echo "  - asset_7: Sub1 active+future cancelled then re-subscribed (nonce 1 re-inserted)"
 echo "  - asset_8: Sub1 subscribed, time advanced 5m, creator+registry fees claimed"
+echo "  - asset_9: Sub1 subscribed, +1000s elapsed, no claim — verifies claimable resolver"

--- a/src/api/asset/resolvers.ts
+++ b/src/api/asset/resolvers.ts
@@ -1,5 +1,58 @@
+import { db } from "ponder:api";
 import schema from "ponder:schema";
+import { eq, sql } from "ponder";
 import { byId, queryList, activeSubscriptionConditions } from "../helpers.js";
+import { getAssetEntityId, getSubscriberClaimableId } from "../../utils";
+
+// Claimable resolvers read from the SubscriberClaimable rollup maintained by
+// src/handlers/claimable.ts. They are pure DB lookups — no math happens here.
+// `asOf*` reflects the rollup row's last refresh (most recent event or
+// block-interval refresh, whichever is more recent).
+const claimableForSubscriber = async (chainId: number, assetAddress: string, subscriber: string) => {
+  const id = getSubscriberClaimableId(chainId, assetAddress, subscriber);
+  const [row] = await (db as any)
+    .select({
+      creatorFee: schema.SubscriberClaimable.creatorFee,
+      registryFee: schema.SubscriberClaimable.registryFee,
+      refreshedAtTimestamp: schema.SubscriberClaimable.refreshedAtTimestamp,
+      refreshedAtBlock: schema.SubscriberClaimable.refreshedAtBlock,
+    })
+    .from(schema.SubscriberClaimable)
+    .where(eq(schema.SubscriberClaimable.id, id))
+    .limit(1);
+
+  if (!row) return { creatorFee: 0n, registryFee: 0n, asOfTimestamp: 0n, asOfBlock: 0n };
+  return {
+    creatorFee: BigInt(row.creatorFee),
+    registryFee: BigInt(row.registryFee),
+    asOfTimestamp: BigInt(row.refreshedAtTimestamp),
+    asOfBlock: BigInt(row.refreshedAtBlock),
+  };
+};
+
+const claimableForAsset = async (chainId: number, assetAddress: string) => {
+  const assetEntityId = getAssetEntityId(chainId, assetAddress);
+  // Single aggregate query: SUM the fees, COUNT the rows, MIN the refreshedAt
+  // (most-stale row in the aggregate — the honest staleness floor).
+  const [agg] = await (db as any)
+    .select({
+      creatorFee: sql<string>`COALESCE(SUM(${schema.SubscriberClaimable.creatorFee}), 0)`,
+      registryFee: sql<string>`COALESCE(SUM(${schema.SubscriberClaimable.registryFee}), 0)`,
+      subscriberCount: sql<string>`COUNT(*)`,
+      asOfTimestamp: sql<string>`COALESCE(MIN(${schema.SubscriberClaimable.refreshedAtTimestamp}), 0)`,
+      asOfBlock: sql<string>`COALESCE(MIN(${schema.SubscriberClaimable.refreshedAtBlock}), 0)`,
+    })
+    .from(schema.SubscriberClaimable)
+    .where(eq(schema.SubscriberClaimable.assetEntityId, assetEntityId));
+
+  return {
+    creatorFee: BigInt(agg?.creatorFee ?? 0),
+    registryFee: BigInt(agg?.registryFee ?? 0),
+    asOfTimestamp: BigInt(agg?.asOfTimestamp ?? 0),
+    asOfBlock: BigInt(agg?.asOfBlock ?? 0),
+    subscriberCount: Number(agg?.subscriberCount ?? 0),
+  };
+};
 
 export const resolvers = {
   Query: {
@@ -20,6 +73,8 @@ export const resolvers = {
       queryList(schema.Subscription, { ...a.where, assetId: parent.id }, a.orderBy, a.orderDirection, a.limit, a.offset),
     activeSubscriptions: (parent: any, a: any) =>
       queryList(schema.Subscription, { ...a.where, assetId: parent.id }, a.orderBy, a.orderDirection, a.limit, a.offset, activeSubscriptionConditions()),
+    claimable:      (parent: any, a: any) => claimableForSubscriber(parent.chainId, parent.address, a.subscriber),
+    claimableTotal: (parent: any) => claimableForAsset(parent.chainId, parent.address),
   },
 
   Asset_CreatorFeeClaimed: {

--- a/src/api/asset/typeDefs.ts
+++ b/src/api/asset/typeDefs.ts
@@ -9,8 +9,31 @@ export const typeDefs = /* GraphQL */ `
     registry: Registry
     subscriptions(where: SubscriptionFilter, orderBy: String, orderDirection: String, limit: Int, offset: Int): SubscriptionPage
     activeSubscriptions(where: SubscriptionFilter, orderBy: String, orderDirection: String, limit: Int, offset: Int): SubscriptionPage
+
+    # Claimable amounts computed from indexed Subscription rows + last claim
+    # pointers. "asOf" reflects the indexer's latest indexed block for this
+    # chain, not wall-clock; the on-chain numbers will continue accruing.
+    claimable(subscriber: String!): ClaimableAmount!
+    claimableTotal: ClaimableTotal!
   }
+
+  type ClaimableAmount {
+    creatorFee: BigInt!
+    registryFee: BigInt!
+    asOfTimestamp: BigInt!
+    asOfBlock: BigInt!
+  }
+
+  type ClaimableTotal {
+    creatorFee: BigInt!
+    registryFee: BigInt!
+    asOfTimestamp: BigInt!
+    asOfBlock: BigInt!
+    subscriberCount: Int!
+  }
+
   type AssetPage { items: [Asset!]! pageInfo: PageInfo! totalCount: Int! }
+  
   input AssetFilter {
     id: String  chainId: Int  assetId: String  address: Address
     registryId: String  registryAddress: Address  owner: Address

--- a/src/handlers/asset.ts
+++ b/src/handlers/asset.ts
@@ -14,6 +14,7 @@ import {
   Asset_OwnershipTransferred,
 } from "../../ponder.schema";
 import { getEventId, getAssetEntityId, getSubscriptionId } from "../utils";
+import { refreshSubscriberClaimable, deleteSubscriberClaimable } from "./claimable";
 
 ponder.on("Asset:SubscriptionAdded", async ({ event, context }) => {
   const chainId = context.chain?.id as number;
@@ -47,6 +48,14 @@ ponder.on("Asset:SubscriptionAdded", async ({ event, context }) => {
     subscriptionPrice: event.args.subscriptionPrice,
     registryFeeShare: event.args.registryFeeShare,
     assetAddress: assetAddress,
+    blockNumber: event.block.number,
+    blockTimestamp: event.block.timestamp,
+  });
+
+  await refreshSubscriberClaimable(context, {
+    chainId,
+    assetAddress,
+    subscriber,
     blockNumber: event.block.number,
     blockTimestamp: event.block.timestamp,
   });
@@ -88,6 +97,14 @@ ponder.on("Asset:SubscriptionRenewed", async ({ event, context }) => {
     blockNumber: event.block.number,
     blockTimestamp: event.block.timestamp,
   });
+
+  await refreshSubscriberClaimable(context, {
+    chainId,
+    assetAddress,
+    subscriber,
+    blockNumber: event.block.number,
+    blockTimestamp: event.block.timestamp,
+  });
 });
 
 ponder.on("Asset:SubscriptionExtended", async ({ event, context }) => {
@@ -125,6 +142,14 @@ ponder.on("Asset:SubscriptionExtended", async ({ event, context }) => {
     blockNumber: event.block.number,
     blockTimestamp: event.block.timestamp,
   });
+
+  await refreshSubscriberClaimable(context, {
+    chainId,
+    assetAddress,
+    subscriber,
+    blockNumber: event.block.number,
+    blockTimestamp: event.block.timestamp,
+  });
 });
 
 ponder.on("Asset:CreatorFeeClaimed", async ({ event, context }) => {
@@ -155,6 +180,24 @@ ponder.on("Asset:CreatorFeeClaimed", async ({ event, context }) => {
     assetAddress: assetAddress,
     blockNumber: event.block.number,
     blockTimestamp: event.block.timestamp,
+  });
+
+  // Bump creator pointer to the event's values and let computeClaimable derive
+  // the post-claim creatorFee — which will be 0 because the contract just paid
+  // out everything claimable up to event.args.claimedAtTimestamp. Registry
+  // pointer is left as-is (the existing rollup row's value).
+  await refreshSubscriberClaimable(context, {
+    chainId,
+    assetAddress,
+    subscriber,
+    blockNumber: event.block.number,
+    blockTimestamp: event.block.timestamp,
+    pointerOverrides: {
+      creator: {
+        claimedAtNonce: event.args.claimedAtNonce,
+        claimedAtTimestamp: event.args.claimedAtTimestamp,
+      },
+    },
   });
 });
 
@@ -193,6 +236,14 @@ ponder.on("Asset:SubscriptionRevoked", async ({ event, context }) => {
     nonce: revokedNonce,
     endTime: event.args.endTime,
     assetAddress: assetAddress,
+    blockNumber: event.block.number,
+    blockTimestamp: event.block.timestamp,
+  });
+
+  await refreshSubscriberClaimable(context, {
+    chainId,
+    assetAddress,
+    subscriber,
     blockNumber: event.block.number,
     blockTimestamp: event.block.timestamp,
   });
@@ -235,6 +286,14 @@ ponder.on("Asset:SubscriptionCancelled", async ({ event, context }) => {
     blockNumber: event.block.number,
     blockTimestamp: event.block.timestamp,
   });
+
+  await refreshSubscriberClaimable(context, {
+    chainId,
+    assetAddress,
+    subscriber,
+    blockNumber: event.block.number,
+    blockTimestamp: event.block.timestamp,
+  });
 });
 
 ponder.on("Asset:SubscriptionRemoved", async ({ event, context }) => {
@@ -264,6 +323,10 @@ ponder.on("Asset:SubscriptionRemoved", async ({ event, context }) => {
     blockNumber: event.block.number,
     blockTimestamp: event.block.timestamp,
   });
+
+  // All subscription rows for this (asset, subscriber) were deleted above;
+  // drop the rollup row too so claimable correctly reports 0.
+  await deleteSubscriberClaimable(context, chainId, assetAddress, subscriber);
 });
 
 ponder.on("Asset:SubscriptionPriceUpdated", async ({ event, context }) => {

--- a/src/handlers/claimable.ts
+++ b/src/handlers/claimable.ts
@@ -1,0 +1,319 @@
+import { ponder } from "ponder:registry";
+import { and, asc, eq, gt, gte } from "ponder";
+import {
+  AssetEntity,
+  Subscription,
+  SubscriberClaimable,
+} from "../../ponder.schema";
+import { getAssetEntityId, getSubscriberClaimableId } from "../utils";
+
+// ── Pure math ────────────────────────────────────────────────────────────────
+// TypeScript port of Asset._claimable() from open-creator-rails (Asset.sol:289).
+// Pure over already-fetched inputs so the surrounding helpers can fetch in
+// whatever shape suits the call site (single-row event handler vs. bulk
+// block-interval refresh).
+//
+// IMPORTANT: must stay faithful to the contract. If _claimable() changes
+// upstream, this has to mirror it.
+
+export type PointerState = {
+  claimedAtNonce: bigint;
+  claimedAtTimestamp: bigint;
+};
+
+export type SubscriptionRow = {
+  nonce: bigint;
+  startTime: bigint;
+  endTime: bigint;
+  subscriptionPrice: bigint;
+  registryFeeShare: bigint;
+};
+
+export type ClaimableResult = {
+  creatorFee: bigint;
+  registryFee: bigint;
+  creator: PointerState;
+  registry: PointerState;
+};
+
+export function computeClaimable(
+  subscriptions: SubscriptionRow[],
+  duration: bigint,
+  asOfTimestamp: bigint,
+  creator: PointerState,
+  registry: PointerState,
+): ClaimableResult {
+  let creatorFee = 0n;
+  let registryFee = 0n;
+  let cNonce = creator.claimedAtNonce;
+  let cAt = creator.claimedAtTimestamp;
+  let rNonce = registry.claimedAtNonce;
+  let rAt = registry.claimedAtTimestamp;
+
+  for (const sub of subscriptions) {
+    // Mirrors the contract's `break`: subsequent (higher-nonce) subscriptions
+    // start at the same time or later, so once a nonce starts at/after the
+    // asOf horizon the rest contribute nothing.
+    if (sub.startTime >= asOfTimestamp) break;
+
+    if (sub.nonce >= cNonce && sub.endTime > cAt) {
+      const start = sub.startTime > cAt ? sub.startTime : cAt;
+      const end = sub.endTime < asOfTimestamp ? sub.endTime : asOfTimestamp;
+      const count = (end - start) / duration;
+      if (count > 0n) {
+        const fee = count * sub.subscriptionPrice;
+        const regPortion = (fee * sub.registryFeeShare) / 100n;
+        creatorFee += fee - regPortion;
+        cNonce = sub.nonce;
+        cAt = start + count * duration;
+      }
+    }
+
+    if (sub.nonce >= rNonce && sub.endTime > rAt) {
+      const start = sub.startTime > rAt ? sub.startTime : rAt;
+      const end = sub.endTime < asOfTimestamp ? sub.endTime : asOfTimestamp;
+      const count = (end - start) / duration;
+      if (count > 0n) {
+        const fee = count * sub.subscriptionPrice;
+        const regPortion = (fee * sub.registryFeeShare) / 100n;
+        registryFee += regPortion;
+        rNonce = sub.nonce;
+        rAt = start + count * duration;
+      }
+    }
+  }
+
+  return {
+    creatorFee,
+    registryFee,
+    creator: { claimedAtNonce: cNonce, claimedAtTimestamp: cAt },
+    registry: { claimedAtNonce: rNonce, claimedAtTimestamp: rAt },
+  };
+}
+
+// ── Rollup maintenance ───────────────────────────────────────────────────────
+//
+// The SubscriberClaimable rollup is the single source of truth for the
+// `Asset.claimable(...)` GraphQL fields. It is maintained from two directions:
+//
+//   1. EVENT-DRIVEN (refreshSubscriberClaimable):
+//      Every subscription/claim event handler calls into this helper after
+//      writing its primary state so the rollup reflects the post-event truth.
+//      Pointer overrides let CreatorFeeClaimed / RegistryFeeClaimed bump the
+//      relevant side's pointer in one call.
+//
+//   2. BLOCK-INTERVAL (refreshAllSubscriberClaimable, triggered by the
+//      ClaimableRefresh:block handler at the bottom of this file):
+//      Catches the "time elapsed without any event firing" case — fees accrue
+//      on every period boundary even when nothing happens on-chain.
+
+/**
+ * Refresh the rollup row for a single (asset, subscriber). Reads
+ * subscriptionDuration from AssetEntity, current pointers from the existing
+ * rollup row (or zero if none), all Subscription rows for the pair, runs the
+ * pure computeClaimable, and upserts.
+ *
+ * If the asset is missing (handler fired before AssetCreated indexed) this is
+ * a no-op rather than an error — the rollup will be populated on the next
+ * subscription event for that asset.
+ */
+export async function refreshSubscriberClaimable(
+  context: any,
+  args: {
+    chainId: number;
+    assetAddress: string;        // lowercased
+    subscriber: string;
+    blockNumber: bigint;
+    blockTimestamp: bigint;
+    pointerOverrides?: {
+      creator?: PointerState;
+      registry?: PointerState;
+    };
+  },
+): Promise<void> {
+  const { chainId, blockNumber, blockTimestamp, pointerOverrides } = args;
+  const assetAddress = args.assetAddress.toLowerCase();
+  const assetEntityId = getAssetEntityId(chainId, assetAddress);
+  const rollupId = getSubscriberClaimableId(chainId, assetAddress, args.subscriber);
+
+  const [asset] = await context.db.sql
+    .select({ subscriptionDuration: AssetEntity.subscriptionDuration })
+    .from(AssetEntity)
+    .where(eq(AssetEntity.id, assetEntityId))
+    .limit(1);
+  if (!asset?.subscriptionDuration) return;
+  const duration = BigInt(asset.subscriptionDuration);
+
+  // Existing rollup row gives us the previously-known pointer state. First
+  // refresh after SubscriptionAdded won't find a row → defaults to zero,
+  // matching the contract's zero-init.
+  const [existing] = await context.db.sql
+    .select({
+      creatorClaimedAtNonce: SubscriberClaimable.creatorClaimedAtNonce,
+      creatorClaimedAtTimestamp: SubscriberClaimable.creatorClaimedAtTimestamp,
+      registryClaimedAtNonce: SubscriberClaimable.registryClaimedAtNonce,
+      registryClaimedAtTimestamp: SubscriberClaimable.registryClaimedAtTimestamp,
+    })
+    .from(SubscriberClaimable)
+    .where(eq(SubscriberClaimable.id, rollupId))
+    .limit(1);
+
+  const creator: PointerState = pointerOverrides?.creator ?? {
+    claimedAtNonce: BigInt(existing?.creatorClaimedAtNonce ?? 0n),
+    claimedAtTimestamp: BigInt(existing?.creatorClaimedAtTimestamp ?? 0n),
+  };
+  const registry: PointerState = pointerOverrides?.registry ?? {
+    claimedAtNonce: BigInt(existing?.registryClaimedAtNonce ?? 0n),
+    claimedAtTimestamp: BigInt(existing?.registryClaimedAtTimestamp ?? 0n),
+  };
+
+  // Floor the fetch at the lower of the two per-side pointers. Rows below
+  // this nonce get skipped by computeClaimable's per-side guards anyway, so
+  // there's no behavioral difference — just a smaller result set. Uses the
+  // indexed `nonce` column for a range scan.
+  const minClaimedNonce = creator.claimedAtNonce < registry.claimedAtNonce
+    ? creator.claimedAtNonce
+    : registry.claimedAtNonce;
+
+  const subs: SubscriptionRow[] = await context.db.sql
+    .select({
+      nonce: Subscription.nonce,
+      startTime: Subscription.startTime,
+      endTime: Subscription.endTime,
+      subscriptionPrice: Subscription.subscriptionPrice,
+      registryFeeShare: Subscription.registryFeeShare,
+    })
+    .from(Subscription)
+    .where(and(
+      eq(Subscription.assetId, assetEntityId),
+      eq(Subscription.subscriber, args.subscriber),
+      gte(Subscription.nonce, minClaimedNonce),
+    ))
+    .orderBy(asc(Subscription.nonce));
+
+  const result = computeClaimable(subs, duration, blockTimestamp, creator, registry);
+
+  await context.db.insert(SubscriberClaimable).values({
+    id: rollupId,
+    chainId,
+    assetEntityId,
+    subscriber: args.subscriber,
+    creatorClaimedAtNonce: result.creator.claimedAtNonce,
+    creatorClaimedAtTimestamp: result.creator.claimedAtTimestamp,
+    registryClaimedAtNonce: result.registry.claimedAtNonce,
+    registryClaimedAtTimestamp: result.registry.claimedAtTimestamp,
+    creatorFee: result.creatorFee,
+    registryFee: result.registryFee,
+    refreshedAtBlock: blockNumber,
+    refreshedAtTimestamp: blockTimestamp,
+  }).onConflictDoUpdate({
+    creatorClaimedAtNonce: result.creator.claimedAtNonce,
+    creatorClaimedAtTimestamp: result.creator.claimedAtTimestamp,
+    registryClaimedAtNonce: result.registry.claimedAtNonce,
+    registryClaimedAtTimestamp: result.registry.claimedAtTimestamp,
+    creatorFee: result.creatorFee,
+    registryFee: result.registryFee,
+    refreshedAtBlock: blockNumber,
+    refreshedAtTimestamp: blockTimestamp,
+  });
+}
+
+/**
+ * Delete a rollup row. Used by SubscriptionRemoved (subscriber removed from
+ * the asset entirely; future-nonces deleted). Safe to call when no row exists.
+ */
+export async function deleteSubscriberClaimable(
+  context: any,
+  chainId: number,
+  assetAddress: string,
+  subscriber: string,
+): Promise<void> {
+  const rollupId = getSubscriberClaimableId(chainId, assetAddress, subscriber);
+  await context.db.delete(SubscriberClaimable, { id: rollupId }).catch(() => {});
+}
+
+/**
+ * Block-interval refresh entry point. Iterates every rollup row on the given
+ * chain via keyset pagination on the indexed `id` PK so we never load the full
+ * rollup table into memory. Each batch is BATCH_SIZE rows; the per-row refresh
+ * still does ~3 queries (asset, existing rollup, subs) + 1 upsert, so total
+ * work is O(N) but memory stays bounded.
+ *
+ * If N grows into the hundreds of thousands and the per-row fan-out becomes
+ * the bottleneck, the next step is to push the recompute into SQL or batch-
+ * fetch (assets, subs) for each page.
+ */
+const BATCH_SIZE = 500;
+
+export async function refreshAllSubscriberClaimable(
+  context: any,
+  args: { chainId: number; blockNumber: bigint; blockTimestamp: bigint },
+): Promise<void> {
+  const { chainId, blockNumber, blockTimestamp } = args;
+  const startedAt = Date.now();
+  let refreshed = 0;
+
+  let cursor: string | null = null;
+  while (true) {
+    const where = cursor === null
+      ? eq(SubscriberClaimable.chainId, chainId)
+      : and(
+          eq(SubscriberClaimable.chainId, chainId),
+          gt(SubscriberClaimable.id, cursor),
+        );
+
+    const page: Array<{ id: string; assetEntityId: string; subscriber: string }> =
+      await context.db.sql
+        .select({
+          id: SubscriberClaimable.id,
+          assetEntityId: SubscriberClaimable.assetEntityId,
+          subscriber: SubscriberClaimable.subscriber,
+        })
+        .from(SubscriberClaimable)
+        .where(where)
+        .orderBy(asc(SubscriberClaimable.id))
+        .limit(BATCH_SIZE);
+
+    if (page.length === 0) break;
+
+    for (const row of page) {
+      // assetEntityId is `${chainId}_${assetAddress}` — strip the chainId prefix to
+      // recover the address for refreshSubscriberClaimable's lowercase input.
+      const assetAddress = row.assetEntityId.slice(String(chainId).length + 1);
+      await refreshSubscriberClaimable(context, {
+        chainId,
+        assetAddress,
+        subscriber: row.subscriber,
+        blockNumber,
+        blockTimestamp,
+      });
+      refreshed += 1;
+    }
+
+    if (page.length < BATCH_SIZE) break;
+    cursor = page[page.length - 1]!.id;
+  }
+
+  // Visibility for the optimisation signal documented in the README:
+  // sustained duration > 10s here is the cue to switch to per-page batch
+  // fetches inside refreshSubscriberClaimable. Logged on every fire so
+  // refresh lag is observable in indexer logs without extra instrumentation.
+  const durationMs = Date.now() - startedAt;
+  console.info(
+    `[ClaimableRefresh] chainId=${chainId} block=${blockNumber} refreshed=${refreshed} duration=${durationMs}ms`,
+  );
+}
+
+// ── Block-interval refresh trigger ───────────────────────────────────────────
+// Registered against the `ClaimableRefresh` block source declared in
+// ponder.config.ts. Fires on each chain's configured interval (Sepolia ~24h,
+// local every block) and brings every rollup row's fee values up to date with
+// the current block timestamp.
+ponder.on("ClaimableRefresh:block", async ({ event, context }) => {
+  const chainId = context.chain?.id as number;
+  await refreshAllSubscriberClaimable(context, {
+    chainId,
+    blockNumber: event.block.number,
+    blockTimestamp: event.block.timestamp,
+  });
+});

--- a/src/handlers/claimable.ts
+++ b/src/handlers/claimable.ts
@@ -1,5 +1,5 @@
 import { ponder } from "ponder:registry";
-import { and, asc, eq, gt, gte } from "ponder";
+import { and, asc, eq, gt, gte, lte } from "ponder";
 import {
   AssetEntity,
   Subscription,
@@ -188,6 +188,10 @@ export async function refreshSubscriberClaimable(
       eq(Subscription.assetId, assetEntityId),
       eq(Subscription.subscriber, args.subscriber),
       gte(Subscription.nonce, minClaimedNonce),
+      // Drop future-dated nonces at the query level. computeClaimable's `break`
+      // already discards them, but no point fetching what we'd throw away.
+      // Uses the indexed startTime column.
+      lte(Subscription.startTime, blockTimestamp),
     ))
     .orderBy(asc(Subscription.nonce));
 

--- a/src/handlers/claimable.ts
+++ b/src/handlers/claimable.ts
@@ -193,24 +193,36 @@ export async function refreshSubscriberClaimable(
 
   const result = computeClaimable(subs, duration, blockTimestamp, creator, registry);
 
+  // Persist the INPUT pointers, not the loop's advanced output.
+  //
+  // computeClaimable advances cNonce/cAt internally so it can sum fees across
+  // multiple nonces in one call — those advanced values are a loop variable,
+  // NOT a new claim point. The on-chain pointers (creatorClaimedAtTimestamps,
+  // creatorClaimedAtNonces) only move when an actual claim transaction runs,
+  // which surfaces here as CreatorFeeClaimed / RegistryFeeClaimed events
+  // applying pointerOverrides.
+  //
+  // Writing result.creator.* back would falsely "advance" the rollup pointer
+  // every refresh, so subsequent refreshes against the same asOf would
+  // compute count=0 and store fees=0, collapsing accrued claimable to zero.
   await context.db.insert(SubscriberClaimable).values({
     id: rollupId,
     chainId,
     assetEntityId,
     subscriber: args.subscriber,
-    creatorClaimedAtNonce: result.creator.claimedAtNonce,
-    creatorClaimedAtTimestamp: result.creator.claimedAtTimestamp,
-    registryClaimedAtNonce: result.registry.claimedAtNonce,
-    registryClaimedAtTimestamp: result.registry.claimedAtTimestamp,
+    creatorClaimedAtNonce: creator.claimedAtNonce,
+    creatorClaimedAtTimestamp: creator.claimedAtTimestamp,
+    registryClaimedAtNonce: registry.claimedAtNonce,
+    registryClaimedAtTimestamp: registry.claimedAtTimestamp,
     creatorFee: result.creatorFee,
     registryFee: result.registryFee,
     refreshedAtBlock: blockNumber,
     refreshedAtTimestamp: blockTimestamp,
   }).onConflictDoUpdate({
-    creatorClaimedAtNonce: result.creator.claimedAtNonce,
-    creatorClaimedAtTimestamp: result.creator.claimedAtTimestamp,
-    registryClaimedAtNonce: result.registry.claimedAtNonce,
-    registryClaimedAtTimestamp: result.registry.claimedAtTimestamp,
+    creatorClaimedAtNonce: creator.claimedAtNonce,
+    creatorClaimedAtTimestamp: creator.claimedAtTimestamp,
+    registryClaimedAtNonce: registry.claimedAtNonce,
+    registryClaimedAtTimestamp: registry.claimedAtTimestamp,
     creatorFee: result.creatorFee,
     registryFee: result.registryFee,
     refreshedAtBlock: blockNumber,

--- a/src/handlers/registry.ts
+++ b/src/handlers/registry.ts
@@ -11,6 +11,7 @@ import {
   AssetRegistry_RegistryFeeClaimed,
 } from "../../ponder.schema";
 import { getEventId, getAssetEntityId, getRegistryEntityId, getSubscriptionId } from "../utils";
+import { refreshSubscriberClaimable } from "./claimable";
 
 ponder.on("AssetRegistry:AssetCreated", async ({ event, context }) => {
   const chainId = context.chain?.id as number;
@@ -159,4 +160,23 @@ ponder.on("AssetRegistry:RegistryFeeClaimed", async ({ event, context }) => {
     blockNumber: event.block.number,
     blockTimestamp: event.block.timestamp,
   });
+
+  // Bump registry pointer to the event's values; creator pointer is preserved
+  // from the existing rollup row. Post-claim registryFee will be 0 because the
+  // contract just paid out everything claimable up to event.args.claimedAtTimestamp.
+  if (assetRow) {
+    await refreshSubscriberClaimable(context, {
+      chainId,
+      assetAddress: assetRow.address,
+      subscriber,
+      blockNumber: event.block.number,
+      blockTimestamp: event.block.timestamp,
+      pointerOverrides: {
+        registry: {
+          claimedAtNonce: event.args.claimedAtNonce,
+          claimedAtTimestamp: event.args.claimedAtTimestamp,
+        },
+      },
+    });
+  }
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 import "./handlers/registry";
 import "./handlers/asset";
+import "./handlers/claimable";

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -13,3 +13,7 @@ export const getAssetEntityId = (chainId: number, assetAddress: string) => {
 export const getSubscriptionId = (chainId: number, assetAddress: string, subscriber: string, nonce: bigint) => {
   return `${chainId}_${assetAddress.toLowerCase()}_${subscriber}_${nonce}`;
 };
+
+export const getSubscriberClaimableId = (chainId: number, assetAddress: string, subscriber: string) => {
+  return `${chainId}_${assetAddress.toLowerCase()}_${subscriber}`;
+};


### PR DESCRIPTION
Closes #32 

## Summary

Adds `Asset.claimable(subscriber)` and `Asset.claimableTotal` GraphQL fields that return creator and registry fee amounts currently claimable on an asset. Both expose `asOfTimestamp` / `asOfBlock` so consumers can reason about indexer freshness.

The math is a faithful TS port of `Asset._claimable()` ([Asset.sol:289](open-creator-rails/src/Asset.sol#L289)).
It runs at write time (event handlers + block-interval refresh), so GraphQL reads are point lookups — not on-demand integration.

## Design

Claimable is a function of `(subscription state, block.timestamp)` — it grows whenever a period boundary crosses, with or without an on-chain event. Two simpler designs were rejected (full rationale in [README → Claimable Amounts]:

- **Compute on read in resolvers** → per-asset totals fan out to `O(N_subscribers)` round-trips per query, ~50s at 1000+ subscribers on remote Postgres.
- **Store final values, update only on events** → values go stale between events; wrong as soon as the next period boundary crosses. Continuous block-level recompute to keep them fresh has prohibitive write amplification.

The chosen design is a `SubscriberClaimable` rollup maintained from two directions:
1. Event-driven — every subscription/claim event handler upserts the row's pointers and recomputes fees against `event.block.timestamp`. Exact at the event.
2. Block-interval — `ClaimableRefresh:block` handler (declared in `ponder.config.ts`) fires every N blocks and recomputes fees for every rollup row against the current block's timestamp. Catches time-only updates.

Reads:
- `Asset.claimable(subscriber)` → one PK lookup.
- `Asset.claimableTotal` → one aggregate (`SUM` / `COUNT` / `MIN`) over rollup rows for the asset.

## Known limitations

- Refresh cost at scale - The block-interval handler iterates every rollup row per fire with ~4 queries per row. At 10k subscribers chain-wide that's ~100s of wall-clock per fire, running synchronously in the indexing pipeline. Acceptable at Sepolia's daily cadence today; README documents the optimisation signal (`refreshedAtBlock` lag >10s) and the path (per-page batch fetches, ~10× faster, no schema / math change).
- Faithfulness coupling - The math must mirror `Asset._claimable()` exactly. A contract change upstream would silently drift the indexer unless this file is updated in lockstep. Worth a parity check if it becomes a recurring concern.