### PR TITLE
feat(test): add vitest e2e harness for indexer + /v2/graphql

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -24,8 +24,14 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
 
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+
+      - name: Build contracts
+        run: pnpm contracts:build
 
       - name: Codegen
         run: pnpm codegen
@@ -35,3 +41,6 @@ jobs:
 
       - name: Typecheck
         run: pnpm typecheck
+
+      - name: Test
+        run: pnpm test

--- a/config/index.ts
+++ b/config/index.ts
@@ -9,3 +9,22 @@ import localDeployments from './deployments/registries_31337.json';
 import tokenAddresses from './deployments/token_addresses.json';
 
 export { sepoliaDeployments, baseSepoliaDeployments, localDeployments, tokenAddresses };
+
+// Returns the AssetRegistry addresses Ponder should track for `chainId`.
+// `PONDER_${chainId}_REGISTRIES` (JSON array of addresses) takes precedence
+// over the on-disk deployments JSON when set — the e2e test harness uses this
+// to point Ponder at a registry it just deployed without mutating tracked files.
+export function registryAddressesForChain(
+  chainId: number,
+  deployments: ReadonlyArray<{ address: string }>,
+): `0x${string}`[] {
+  const envVar = process.env[`PONDER_${chainId}_REGISTRIES`];
+  const addresses = envVar
+    ? (JSON.parse(envVar) as string[])
+    : deployments.map((d) => d.address);
+  return addresses.map((a) => a as `0x${string}`);
+}
+
+export const sepoliaRegistryAddresses = registryAddressesForChain(11155111, sepoliaDeployments);
+export const baseSepoliaRegistryAddresses = registryAddressesForChain(84532, baseSepoliaDeployments);
+export const localRegistryAddresses = registryAddressesForChain(31337, localDeployments);

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "typecheck": "tsc",
     "contracts:build": "cd open-creator-rails && forge build",
     "sync": "pnpm contracts:build && node scripts/sync-abis.js",
-    "sync:deployments": "node scripts/sync-deployments.js"
+    "sync:deployments": "node scripts/sync-deployments.js",
+    "test": "vitest run"
   },
   "dependencies": {
     "abitype": "^1.2.4",
@@ -30,7 +31,8 @@
     "concurrently": "^9.2.1",
     "eslint": "^8.54.0",
     "eslint-config-ponder": "^0.16.6",
-    "typescript": "^5.3.2"
+    "typescript": "^5.3.2",
+    "vitest": "^3.0.0"
   },
   "engines": {
     "node": ">=18.14"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,6 +42,9 @@ importers:
       typescript:
         specifier: ^5.3.2
         version: 5.9.3
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.4(@types/node@20.19.37)
 
 packages:
 
@@ -320,6 +323,9 @@ packages:
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
 
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
   '@noble/ciphers@1.3.0':
     resolution: {integrity: sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==}
     engines: {node: ^14.21.3 || >=16}
@@ -511,6 +517,12 @@ packages:
   '@scure/bip39@1.6.0':
     resolution: {integrity: sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
@@ -584,6 +596,35 @@ packages:
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
     deprecated: Potential CWE-502 - Update to 1.3.1 or higher
+
+  '@vitest/expect@3.2.4':
+    resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
+
+  '@vitest/mocker@3.2.4':
+    resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@3.2.4':
+    resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
+
+  '@vitest/runner@3.2.4':
+    resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==}
+
+  '@vitest/snapshot@3.2.4':
+    resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==}
+
+  '@vitest/spy@3.2.4':
+    resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
+
+  '@vitest/utils@3.2.4':
+    resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
 
   '@whatwg-node/disposablestack@0.0.6':
     resolution: {integrity: sha512-LOtTn+JgJvX8WfBVJtF08TGrdjuFzGJc4mkP8EdDI8ADbvO7kiexYep1o8dwnt0okb0jYclCDXF13xU7Ge4zSw==}
@@ -697,6 +738,10 @@ packages:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
     engines: {node: '>=8'}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   atomic-sleep@1.0.0:
     resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
     engines: {node: '>=8.0.0'}
@@ -737,9 +782,17 @@ packages:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
 
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
 
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
@@ -795,6 +848,10 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
 
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
@@ -929,6 +986,9 @@ packages:
     resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
     engines: {node: '>=18'}
 
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
   esbuild@0.21.5:
     resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
     engines: {node: '>=12'}
@@ -979,6 +1039,9 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
@@ -997,6 +1060,10 @@ packages:
   execa@5.1.1:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
     engines: {node: '>=10'}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -1024,6 +1091,15 @@ packages:
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
 
   file-entry-cache@6.0.1:
     resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
@@ -1195,6 +1271,9 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
+
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
@@ -1232,8 +1311,14 @@ packages:
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
@@ -1360,6 +1445,13 @@ packages:
   pathe@1.1.2:
     resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
 
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
+
   pg-cloudflare@1.3.0:
     resolution: {integrity: sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==}
 
@@ -1406,6 +1498,10 @@ packages:
   picomatch@2.3.2:
     resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
     engines: {node: '>=8.6'}
+
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
 
   pino-abstract-transport@1.2.0:
     resolution: {integrity: sha512-Guhh8EZfPCfH+PMXAb6rKOjGQEoy0xlAIn+irODG5kgfYV+BQ0rGYYWTIel3P5mmyXqkYkPmdIkywsn6QKUR1Q==}
@@ -1545,6 +1641,9 @@ packages:
     resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
@@ -1567,9 +1666,15 @@ packages:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   stacktrace-parser@0.1.11:
     resolution: {integrity: sha512-WjlahMgHmCJpqzU8bIBy4qtsZdU9lRlcZE3Lvyej6t4tuOuv1vk57OW3MBrj6hXBFx/nNoC9MPMTcr5YA7NQbg==}
     engines: {node: '>=6'}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -1597,6 +1702,9 @@ packages:
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
+
+  strip-literal@3.1.0:
+    resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
 
   stubborn-fs@2.0.0:
     resolution: {integrity: sha512-Y0AvSwDw8y+nlSNFXMm2g6L51rBGdAQT20J3YSOqxC53Lo3bjWRtr2BKcfYoAf352WYpsZSTURrA0tqhfgudPA==}
@@ -1628,6 +1736,28 @@ packages:
 
   thread-stream@2.7.0:
     resolution: {integrity: sha512-qQiRWsU/wvNolI6tbbCKd9iKaTnCXsTwVxhhKM6nctPdujTyztjlbUkUTUymidWcMnZ5pWR0ej4a0tjsW021vw==}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
+    engines: {node: '>=12.0.0'}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@4.0.4:
+    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
+    engines: {node: '>=14.0.0'}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -1707,6 +1837,11 @@ packages:
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
 
+  vite-node@3.2.4:
+    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+
   vite-tsconfig-paths@4.3.1:
     resolution: {integrity: sha512-cfgJwcGOsIxXOLU/nELPny2/LUD/lcf1IbfyeKTv2bsupVbTH/xpFtdQlBmIP1GEK2CjjLxYhFfB+QODFAx5aw==}
     peerDependencies:
@@ -1746,12 +1881,45 @@ packages:
       terser:
         optional: true
 
+  vitest@3.2.4:
+    resolution: {integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.2.4
+      '@vitest/ui': 3.2.4
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   when-exit@2.1.5:
     resolution: {integrity: sha512-VGkKJ564kzt6Ms1dbgPP/yuIoQCrsFAnRbptpC5wOEsDaNsbCB2bnfnaA8i/vRs5tjUSEOtIuvl9/MyVsvQZCg==}
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   word-wrap@1.2.5:
@@ -2095,6 +2263,8 @@ snapshots:
       wrap-ansi: 8.1.0
       wrap-ansi-cjs: wrap-ansi@7.0.0
 
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
   '@noble/ciphers@1.3.0': {}
 
   '@noble/curves@1.9.1':
@@ -2216,6 +2386,13 @@ snapshots:
       '@noble/hashes': 1.8.0
       '@scure/base': 1.2.6
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
   '@types/estree@1.0.8': {}
 
   '@types/json-schema@7.0.15': {}
@@ -2314,6 +2491,48 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
+  '@vitest/expect@3.2.4':
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      tinyrainbow: 2.0.0
+
+  '@vitest/mocker@3.2.4(vite@5.4.21(@types/node@20.19.37))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 5.4.21(@types/node@20.19.37)
+
+  '@vitest/pretty-format@3.2.4':
+    dependencies:
+      tinyrainbow: 2.0.0
+
+  '@vitest/runner@3.2.4':
+    dependencies:
+      '@vitest/utils': 3.2.4
+      pathe: 2.0.3
+      strip-literal: 3.1.0
+
+  '@vitest/snapshot@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@3.2.4':
+    dependencies:
+      tinyspy: 4.0.4
+
+  '@vitest/utils@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      loupe: 3.2.1
+      tinyrainbow: 2.0.0
+
   '@whatwg-node/disposablestack@0.0.6':
     dependencies:
       '@whatwg-node/promise-helpers': 1.3.2
@@ -2405,6 +2624,8 @@ snapshots:
 
   array-union@2.1.0: {}
 
+  assertion-error@2.0.1: {}
+
   atomic-sleep@1.0.0: {}
 
   atomically@2.1.1:
@@ -2444,10 +2665,20 @@ snapshots:
 
   callsites@3.1.0: {}
 
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
+
+  check-error@2.1.3: {}
 
   cliui@8.0.1:
     dependencies:
@@ -2510,6 +2741,8 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  deep-eql@5.0.2: {}
+
   deep-is@0.1.4: {}
 
   delay@5.0.0: {}
@@ -2548,6 +2781,8 @@ snapshots:
   env-paths@3.0.0: {}
 
   environment@1.1.0: {}
+
+  es-module-lexer@1.7.0: {}
 
   esbuild@0.21.5:
     optionalDependencies:
@@ -2651,6 +2886,10 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
   esutils@2.0.3: {}
 
   event-target-shim@5.0.1: {}
@@ -2670,6 +2909,8 @@ snapshots:
       onetime: 5.1.2
       signal-exit: 3.0.7
       strip-final-newline: 2.0.0
+
+  expect-type@1.3.0: {}
 
   fast-deep-equal@3.1.3: {}
 
@@ -2694,6 +2935,10 @@ snapshots:
   fastq@1.20.1:
     dependencies:
       reusify: 1.1.0
+
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
 
   file-entry-cache@6.0.1:
     dependencies:
@@ -2870,6 +3115,8 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
+  js-tokens@9.0.1: {}
+
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
@@ -2901,7 +3148,13 @@ snapshots:
 
   lodash.merge@4.6.2: {}
 
+  loupe@3.2.1: {}
+
   lru-cache@10.4.3: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   merge-stream@2.0.0: {}
 
@@ -3015,6 +3268,10 @@ snapshots:
 
   pathe@1.1.2: {}
 
+  pathe@2.0.3: {}
+
+  pathval@2.0.1: {}
+
   pg-cloudflare@1.3.0:
     optional: true
 
@@ -3059,6 +3316,8 @@ snapshots:
   picocolors@1.1.1: {}
 
   picomatch@2.3.2: {}
+
+  picomatch@4.0.4: {}
 
   pino-abstract-transport@1.2.0:
     dependencies:
@@ -3279,6 +3538,8 @@ snapshots:
 
   shell-quote@1.8.3: {}
 
+  siginfo@2.0.0: {}
+
   signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
@@ -3293,9 +3554,13 @@ snapshots:
 
   split2@4.2.0: {}
 
+  stackback@0.0.2: {}
+
   stacktrace-parser@0.1.11:
     dependencies:
       type-fest: 0.7.1
+
+  std-env@3.10.0: {}
 
   string-width@4.2.3:
     dependencies:
@@ -3324,6 +3589,10 @@ snapshots:
   strip-final-newline@2.0.0: {}
 
   strip-json-comments@3.1.1: {}
+
+  strip-literal@3.1.0:
+    dependencies:
+      js-tokens: 9.0.1
 
   stubborn-fs@2.0.0:
     dependencies:
@@ -3354,6 +3623,21 @@ snapshots:
   thread-stream@2.7.0:
     dependencies:
       real-require: 0.2.0
+
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
+  tinyglobby@0.2.16:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@2.0.0: {}
+
+  tinyspy@4.0.4: {}
 
   to-regex-range@5.0.1:
     dependencies:
@@ -3430,6 +3714,24 @@ snapshots:
       - supports-color
       - terser
 
+  vite-node@3.2.4(@types/node@20.19.37):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 5.4.21(@types/node@20.19.37)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
   vite-tsconfig-paths@4.3.1(typescript@5.9.3)(vite@5.4.21(@types/node@20.19.37)):
     dependencies:
       debug: 4.4.3
@@ -3450,11 +3752,54 @@ snapshots:
       '@types/node': 20.19.37
       fsevents: 2.3.3
 
+  vitest@3.2.4(@types/node@20.19.37):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(vite@5.4.21(@types/node@20.19.37))
+      '@vitest/pretty-format': 3.2.4
+      '@vitest/runner': 3.2.4
+      '@vitest/snapshot': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.16
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 5.4.21(@types/node@20.19.37)
+      vite-node: 3.2.4(@types/node@20.19.37)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 20.19.37
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
   when-exit@2.1.5: {}
 
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   word-wrap@1.2.5: {}
 

--- a/ponder.config.ts
+++ b/ponder.config.ts
@@ -1,23 +1,23 @@
 import { getAbiItem  } from "viem";
 import { createConfig, factory } from "ponder";
 
-import { 
-  AssetABI, 
+import {
+  AssetABI,
   AssetRegistryABI,
-  sepoliaDeployments,
-  localDeployments
+  localRegistryAddresses,
+  sepoliaRegistryAddresses,
 } from "./config";
 
 // Extract the event strictly
-const AssetCreatedEvent = getAbiItem({ 
-  abi: AssetRegistryABI, 
-  name: "AssetCreated" 
+const AssetCreatedEvent = getAbiItem({
+  abi: AssetRegistryABI,
+  name: "AssetCreated"
 });
 
-const sepoliaRegistryAddresses = sepoliaDeployments.map((d: any) => d.address as `0x${string}`);
-const localRegistryAddresses = localDeployments.map((d: any) => d.address as `0x${string}`);
-
 export default createConfig({
+  ...(process.env.PONDER_PGLITE_DIR
+    ? { database: { kind: "pglite" as const, directory: process.env.PONDER_PGLITE_DIR } }
+    : {}),
   chains: {
     ...(process.env.PONDER_RPC_URL_11155111 ? {
       sepolia: {

--- a/test/e2e/seed/artifacts.ts
+++ b/test/e2e/seed/artifacts.ts
@@ -1,0 +1,58 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import type { Abi, Hex } from "viem";
+import { AssetABI, AssetRegistryABI } from "../../../config/index.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, "../../..");
+const FORGE_OUT = resolve(ROOT, "open-creator-rails/out");
+
+export type ContractName = "Asset" | "AssetRegistry" | "TestToken";
+
+export interface Artifact {
+  abi: Abi;
+  bytecode: Hex;
+}
+
+// ABIs come from config/*ABI.ts (kept fresh by `pnpm sync` + the abi-sync-check
+// CI workflow) so tests and the indexer can't drift apart. TestToken has no
+// indexer-side ABI, so we still parse its Forge artifact.
+// Bytecode always comes from the Forge artifact; config/ tracks ABI only.
+export function loadArtifact(name: ContractName): Artifact {
+  return { abi: loadAbi(name), bytecode: loadBytecode(name) };
+}
+
+function loadAbi(name: ContractName): Abi {
+  switch (name) {
+    case "Asset":
+      return AssetABI as Abi;
+    case "AssetRegistry":
+      return AssetRegistryABI as Abi;
+    case "TestToken":
+      return readArtifact("TestToken").abi as Abi;
+  }
+}
+
+function loadBytecode(name: ContractName): Hex {
+  return readArtifact(name).bytecode.object as Hex;
+}
+
+interface ForgeArtifact {
+  abi: unknown;
+  bytecode: { object: string };
+}
+
+function readArtifact(name: ContractName): ForgeArtifact {
+  const path = resolve(FORGE_OUT, `${name}.sol`, `${name}.json`);
+  let raw: string;
+  try {
+    raw = readFileSync(path, "utf8");
+  } catch (err) {
+    throw new Error(
+      `Forge artifact not found at ${path}. Run 'pnpm contracts:build' before tests.`,
+      { cause: err },
+    );
+  }
+  return JSON.parse(raw) as ForgeArtifact;
+}

--- a/test/e2e/seed/scenarios.ts
+++ b/test/e2e/seed/scenarios.ts
@@ -1,0 +1,146 @@
+import {
+  createPublicClient,
+  createWalletClient,
+  http,
+  keccak256,
+  parseEventLogs,
+  toHex,
+  type Address,
+  type Hex,
+} from "viem";
+import { privateKeyToAccount } from "viem/accounts";
+import { foundry } from "viem/chains";
+import { loadArtifact, type ContractName } from "./artifacts.js";
+
+// Anvil's first default account. Matches seed-local.sh so debugging
+// behavior stays parallel across the shell-seeded and JS-seeded flows.
+export const DEPLOYER_PRIVATE_KEY: Hex =
+  "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
+
+// Base infra deployed once per test world. Tests build on this — create assets,
+// subscriptions, etc. — as needed for their scenario.
+export interface BaseDeployments {
+  tokenAddress: Address;
+  registryAddress: Address;
+  registryFeeShare: number;
+  deployer: Address;
+}
+
+export interface CreatedAsset {
+  address: Address;
+  assetId: string;
+  assetIdHash: Hex;
+  subscriptionPrice: number;
+  subscriptionDuration: number;
+  tokenAddress: Address;
+  owner: Address;
+}
+
+export function makeClients(rpcUrl: string) {
+  const account = privateKeyToAccount(DEPLOYER_PRIVATE_KEY);
+  const transport = http(rpcUrl);
+  const publicClient = createPublicClient({ chain: foundry, transport });
+  const walletClient = createWalletClient({
+    chain: foundry,
+    transport,
+    account,
+  });
+  return { publicClient, walletClient, deployer: account.address };
+}
+
+export type Clients = ReturnType<typeof makeClients>;
+
+async function deployContract(
+  clients: Clients,
+  artifactName: ContractName,
+  args: readonly unknown[] = [],
+): Promise<Address> {
+  const { abi, bytecode } = loadArtifact(artifactName);
+  const hash = await clients.walletClient.deployContract({
+    abi,
+    bytecode,
+    args: args as never,
+    account: clients.walletClient.account!,
+    chain: foundry,
+  });
+  const receipt = await clients.publicClient.waitForTransactionReceipt({
+    hash,
+  });
+  if (!receipt.contractAddress) {
+    throw new Error(`Deploy of ${artifactName} did not return an address`);
+  }
+  return receipt.contractAddress;
+}
+
+// Deploys the shared infra (TestToken + AssetRegistry) every test world needs.
+// Asset/subscription creation is left to individual tests so they can shape
+// scenarios without paying for setup they don't use.
+export async function baseSeed(
+  clients: Clients,
+  registryFeeShare = 80,
+): Promise<BaseDeployments> {
+  const tokenAddress = await deployContract(clients, "TestToken");
+  const registryAddress = await deployContract(clients, "AssetRegistry", [
+    BigInt(registryFeeShare),
+  ]);
+  return {
+    tokenAddress,
+    registryAddress,
+    registryFeeShare,
+    deployer: clients.deployer,
+  };
+}
+
+export async function createAsset(
+  clients: Clients,
+  registry: Address,
+  assetId: string,
+  subscriptionPrice: number,
+  subscriptionDuration: number,
+  tokenAddress: Address,
+  owner: Address,
+): Promise<CreatedAsset> {
+  const { abi } = loadArtifact("AssetRegistry");
+  const assetIdHash = keccak256(toHex(assetId));
+
+  const hash = await clients.walletClient.writeContract({
+    address: registry,
+    abi,
+    functionName: "createAsset",
+    args: [
+      assetIdHash,
+      BigInt(subscriptionPrice),
+      BigInt(subscriptionDuration),
+      tokenAddress,
+      owner,
+    ],
+    account: clients.walletClient.account!,
+    chain: foundry,
+  });
+  const receipt = await clients.publicClient.waitForTransactionReceipt({
+    hash,
+  });
+
+  const [created] = parseEventLogs({
+    abi,
+    eventName: "AssetCreated",
+    logs: receipt.logs,
+  });
+  if (!created) {
+    throw new Error(`AssetCreated event not found in receipt for ${assetId}`);
+  }
+  // `abi` is the wide Abi type (artifact loader returns Abi for any contract),
+  // so parseEventLogs cannot statically resolve AssetCreated's arg shape. The
+  // ABI we passed in is AssetRegistry's; AssetCreated has an `asset` arg.
+  const { asset } = created.args as unknown as { asset: Address };
+
+  return {
+    address: asset,
+    assetId,
+    assetIdHash,
+    subscriptionPrice,
+    subscriptionDuration,
+    tokenAddress,
+    owner,
+  };
+}

--- a/test/e2e/setup.ts
+++ b/test/e2e/setup.ts
@@ -1,0 +1,288 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import { rmSync } from "node:fs";
+import { createConnection, createServer } from "node:net";
+import { dirname, resolve } from "node:path";
+import { setTimeout as sleep } from "node:timers/promises";
+import { fileURLToPath } from "node:url";
+import {
+  baseSeed,
+  makeClients,
+  type BaseDeployments,
+  type Clients,
+} from "./seed/scenarios.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, "../..");
+const PONDER_BIN = resolve(ROOT, "node_modules/.bin/ponder");
+const ANVIL_PORT = 8545;
+const ANVIL_RPC_URL = `http://127.0.0.1:${ANVIL_PORT}`;
+// Isolated PGlite directory per worker. Sits inside .ponder/ (already in
+// .gitignore) and doesn't collide with `pnpm dev:local`'s default .ponder/pglite.
+const PONDER_PGLITE_DIR = resolve(ROOT, ".ponder", `test-pglite-${process.pid}`);
+// Default unknown-chain finality in ponder/utils/finality.ts; chain 31337 hits
+// this branch. Not overridable from ponder.config.ts in 0.16.6.
+const FINALITY_BLOCKS = 30;
+// Mine a few blocks past the finality boundary so the most recent on-chain
+// action is comfortably finalized before we wait on Ponder.
+const FINALITY_BUFFER = 5;
+
+export interface World {
+  graphqlUrl: string;
+  ponderBaseUrl: string;
+  rpcUrl: string;
+  clients: Clients;
+  base: BaseDeployments;
+  // Mine `count` empty Anvil blocks. Defaults to one finality window + buffer,
+  // which is the right amount to push the most recent on-chain action across
+  // the finalized cliff before calling waitForIndex().
+  mine: (count?: number) => Promise<void>;
+  // Polls Ponder's /status until the indexed head reaches the current chain
+  // head minus FINALITY_BLOCKS — i.e. everything currently on chain that could
+  // be finalized is reflected in the DB. Call after on-chain work + mine().
+  waitForIndex: (timeoutMs?: number) => Promise<void>;
+  teardown: () => Promise<void>;
+}
+
+export async function setupWorld(): Promise<World> {
+  await assertPortFree(ANVIL_PORT);
+
+  // Stale PGlite state from a previous crashed run would let Ponder believe
+  // indexing is already done; wipe before starting.
+  rmSync(PONDER_PGLITE_DIR, { recursive: true, force: true });
+
+  const anvil = spawn("anvil", ["--port", String(ANVIL_PORT)], {
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  attachLogPrefix(anvil, "anvil");
+
+  try {
+    await waitForRpc(ANVIL_RPC_URL, 15_000);
+
+    const clients = makeClients(ANVIL_RPC_URL);
+    const base = await baseSeed(clients);
+
+    // Push the registry deploy past finality so /ready can fire as soon as
+    // Ponder backfills it. Tests that need their own on-chain work indexed
+    // call world.mine() + world.waitForIndex() to do the same.
+    await mineEmptyBlocks(ANVIL_RPC_URL, FINALITY_BLOCKS + FINALITY_BUFFER);
+
+    const ponderPort = await pickFreePort();
+    const ponder = spawn(PONDER_BIN, ["start", "--port", String(ponderPort)], {
+      cwd: ROOT,
+      stdio: ["ignore", "pipe", "pipe"],
+      env: {
+        ...process.env,
+        PONDER_RPC_URL_31337: ANVIL_RPC_URL,
+        // Tells config/index.ts which registries to track for chain 31337
+        // (avoids mutating the committed config/deployments/registries_31337.json
+        // file). The generic PONDER_<CHAINID>_REGISTRIES knob is implemented
+        // there for all chains.
+        PONDER_31337_REGISTRIES: JSON.stringify([base.registryAddress]),
+        // Isolated PGlite dir per-pid; rmSync'd at suite start + teardown.
+        PONDER_PGLITE_DIR: PONDER_PGLITE_DIR,
+        // `ponder start` (unlike `dev`) requires an explicit schema.
+        DATABASE_SCHEMA: "public",
+        // Disable the TTY UI; in CI it spams ANSI control codes into the log.
+        NO_COLOR: "1",
+      },
+    });
+    attachLogPrefix(ponder, "ponder");
+
+    const ponderBaseUrl = `http://127.0.0.1:${ponderPort}`;
+    try {
+      await waitForPonderReady(ponderBaseUrl, 90_000);
+    } catch (err) {
+      await killProcess(ponder);
+      await killProcess(anvil);
+      throw err;
+    }
+
+    const teardown = async (): Promise<void> => {
+      await killProcess(ponder);
+      await killProcess(anvil);
+      rmSync(PONDER_PGLITE_DIR, { recursive: true, force: true });
+    };
+
+    return {
+      graphqlUrl: `${ponderBaseUrl}/v2/graphql`,
+      ponderBaseUrl,
+      rpcUrl: ANVIL_RPC_URL,
+      clients,
+      base,
+      mine: (count = FINALITY_BLOCKS + FINALITY_BUFFER) =>
+        mineEmptyBlocks(ANVIL_RPC_URL, count),
+      waitForIndex: (timeoutMs = 30_000) =>
+        waitForIndex(clients, ponderBaseUrl, timeoutMs),
+      teardown,
+    };
+  } catch (err) {
+    await killProcess(anvil);
+    throw err;
+  }
+}
+
+function attachLogPrefix(child: ChildProcess, prefix: string): void {
+  child.stdout?.on("data", (chunk: Buffer) => {
+    process.stderr.write(prefixLines(prefix, chunk.toString("utf8")));
+  });
+  child.stderr?.on("data", (chunk: Buffer) => {
+    process.stderr.write(prefixLines(prefix, chunk.toString("utf8")));
+  });
+}
+
+function prefixLines(prefix: string, text: string): string {
+  return text
+    .split("\n")
+    .map((line, idx, arr) =>
+      idx === arr.length - 1 && line === "" ? line : `[${prefix}] ${line}\n`,
+    )
+    .join("");
+}
+
+async function assertPortFree(port: number): Promise<void> {
+  const inUse = await isPortInUse(port);
+  if (inUse) {
+    throw new Error(
+      `Port ${port} already in use. Stop any running 'pnpm dev:local' (or other Anvil) before running tests.`,
+    );
+  }
+}
+
+function isPortInUse(port: number): Promise<boolean> {
+  return new Promise((resolveFn) => {
+    const socket = createConnection({ port, host: "127.0.0.1" });
+    socket.once("connect", () => {
+      socket.destroy();
+      resolveFn(true);
+    });
+    socket.once("error", () => {
+      socket.destroy();
+      resolveFn(false);
+    });
+  });
+}
+
+function pickFreePort(): Promise<number> {
+  return new Promise((resolveFn, rejectFn) => {
+    const server = createServer();
+    server.unref();
+    server.once("error", rejectFn);
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address();
+      if (addr === null || typeof addr === "string") {
+        rejectFn(new Error("Failed to acquire free port"));
+        return;
+      }
+      const port = addr.port;
+      server.close(() => resolveFn(port));
+    });
+  });
+}
+
+async function mineEmptyBlocks(rpcUrl: string, count: number): Promise<void> {
+  const res = await fetch(rpcUrl, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "anvil_mine",
+      params: [`0x${count.toString(16)}`],
+    }),
+  });
+  if (!res.ok) {
+    throw new Error(`anvil_mine failed: ${res.status} ${res.statusText}`);
+  }
+}
+
+async function waitForRpc(rpcUrl: string, timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(rpcUrl, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "eth_chainId",
+          params: [],
+        }),
+      });
+      if (res.ok) return;
+    } catch {
+      // Anvil not up yet.
+    }
+    await sleep(200);
+  }
+  throw new Error(`Anvil at ${rpcUrl} did not respond within ${timeoutMs}ms`);
+}
+
+async function waitForPonderReady(
+  baseUrl: string,
+  timeoutMs: number,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  let lastStatus: number | undefined;
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(`${baseUrl}/ready`);
+      lastStatus = res.status;
+      if (res.status === 200) return;
+    } catch {
+      // Ponder server not listening yet.
+    }
+    await sleep(500);
+  }
+  throw new Error(
+    `Ponder /ready at ${baseUrl} did not reach 200 within ${timeoutMs}ms (last status: ${lastStatus ?? "no response"})`,
+  );
+}
+
+interface PonderStatus {
+  [chainName: string]: { id: number; block: { number: number; timestamp: number } };
+}
+
+async function waitForIndex(
+  clients: Clients,
+  ponderBaseUrl: string,
+  timeoutMs: number,
+): Promise<void> {
+  const head = await clients.publicClient.getBlockNumber();
+  const target = Number(head) - FINALITY_BLOCKS;
+  if (target <= 0) return; // nothing has been finalized yet.
+
+  const deadline = Date.now() + timeoutMs;
+  let lastIndexed: number | undefined;
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(`${ponderBaseUrl}/status`);
+      if (res.ok) {
+        const status = (await res.json()) as PonderStatus;
+        const indexed = status.local?.block.number;
+        lastIndexed = indexed;
+        if (indexed !== undefined && indexed >= target) return;
+      }
+    } catch {
+      // Server transient error; retry.
+    }
+    await sleep(200);
+  }
+  throw new Error(
+    `Ponder did not index up to block ${target} within ${timeoutMs}ms (last indexed: ${lastIndexed ?? "unknown"})`,
+  );
+}
+
+async function killProcess(child: ChildProcess): Promise<void> {
+  if (child.exitCode !== null || child.signalCode !== null) return;
+  return new Promise((resolveFn) => {
+    const timer = setTimeout(() => {
+      child.kill("SIGKILL");
+    }, 5_000);
+    child.once("exit", () => {
+      clearTimeout(timer);
+      resolveFn();
+    });
+    child.kill("SIGTERM");
+  });
+}

--- a/test/e2e/smoke.test.ts
+++ b/test/e2e/smoke.test.ts
@@ -1,0 +1,100 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createAsset } from "./seed/scenarios.js";
+import { setupWorld, type World } from "./setup.js";
+
+interface GraphQLResponse<T> {
+  data?: T;
+  errors?: { message: string }[];
+}
+
+async function gql<T>(url: string, query: string): Promise<T> {
+  const res = await fetch(url, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ query }),
+  });
+  if (!res.ok) {
+    throw new Error(`GraphQL request failed: ${res.status} ${res.statusText}`);
+  }
+  const body = (await res.json()) as GraphQLResponse<T>;
+  if (body.errors?.length) {
+    throw new Error(
+      `GraphQL errors: ${body.errors.map((e) => e.message).join("; ")}`,
+    );
+  }
+  if (!body.data) {
+    throw new Error("GraphQL response missing data");
+  }
+  return body.data;
+}
+
+describe("e2e smoke", () => {
+  let world: World;
+
+  beforeAll(async () => {
+    world = await setupWorld();
+  });
+
+  afterAll(async () => {
+    await world?.teardown();
+  });
+
+  it("indexes the base registry deployed in setup", async () => {
+    const { registries } = await gql<{
+      registries: {
+        totalCount: number;
+        items: { id: string; chainId: number; address: string }[];
+      };
+    }>(
+      world.graphqlUrl,
+      `{ registries { totalCount items { id chainId address } } }`,
+    );
+
+    expect(registries.totalCount).toBe(1);
+    expect(registries.items[0]!.chainId).toBe(31337);
+    expect(registries.items[0]!.address).toBe(
+      world.base.registryAddress.toLowerCase(),
+    );
+  });
+
+  it("indexes an asset created mid-test", async () => {
+    const asset = await createAsset(
+      world.clients,
+      world.base.registryAddress,
+      "local_asset_1",
+      2,
+      1,
+      world.base.tokenAddress,
+      world.base.deployer,
+    );
+
+    await world.mine();
+    await world.waitForIndex();
+
+    const { assets } = await gql<{
+      assets: {
+        totalCount: number;
+        items: {
+          assetId: string;
+          address: string;
+          registryAddress: string;
+          subscriptionPrice: string;
+          subscriptionDuration: string;
+        }[];
+      };
+    }>(
+      world.graphqlUrl,
+      `{ assets { totalCount items { assetId address registryAddress subscriptionPrice subscriptionDuration } } }`,
+    );
+
+    expect(assets.totalCount).toBe(1);
+    const indexed = assets.items[0]!;
+    // AssetEntity.assetId stores the on-chain bytes32 (keccak of the
+    // human-readable label), not the label itself.
+    expect(indexed.assetId).toBe(asset.assetIdHash);
+    expect(indexed.address).toBe(asset.address.toLowerCase());
+    expect(indexed.registryAddress).toBe(world.base.registryAddress.toLowerCase());
+    expect(indexed.subscriptionPrice).toBe(String(asset.subscriptionPrice));
+    expect(indexed.subscriptionDuration).toBe(String(asset.subscriptionDuration));
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["test/**/*.test.ts"],
+    fileParallelism: false,
+    sequence: { concurrent: false },
+    testTimeout: 60_000,
+    hookTimeout: 120_000,
+    teardownTimeout: 30_000,
+  },
+});


### PR DESCRIPTION
Closes #48  (phase 1 — harness + GraphQL smoke). Handler-level coverage will land in follow-up PRs.

## Summary

- Vitest e2e harness that boots Anvil + Ponder per test file, no shell scripts.
- `baseSeed` deploys TestToken + AssetRegistry; each test calls `createAsset` etc. for its own scenario.
- `world.mine()` + `world.waitForIndex()` push on-chain work past Ponder's finality cliff and wait for the indexed head to catch up.
- Generic `PONDER_<CHAINID>_REGISTRIES` override in `config/index.ts` — tests point Ponder at a per-run registry without touching `config/deployments/*.json`.
- CI runs the new `pnpm test` step after lint + typecheck. Foundry is installed and contracts built so artifacts (bytecode) are available to tests.
