### PR TITLE
fix(indexer): skip ClaimableRefresh ticks during historical backfill

### DIFF
--- a/src/handlers/claimable.ts
+++ b/src/handlers/claimable.ts
@@ -325,7 +325,19 @@ export async function refreshAllSubscriberClaimable(
 // ponder.config.ts. Fires on each chain's configured interval (Sepolia ~24h,
 // local every block) and brings every rollup row's fee values up to date with
 // the current block timestamp.
+//
+// Historical backfill optimization: skip refresh ticks whose block timestamp
+// trails wall-clock by more than HISTORICAL_BACKFILL_LAG_SEC. The rollup is
+// already kept correct by the event-driven path during backfill, and queries
+// can't reach the indexer until /ready fires post-backfill — so intermediate
+// "as of historical block N" values are never read. Skipping them saves
+// O(refresh_ticks × subscribers) work on chains with a long startBlock-to-head
+// distance.
+const HISTORICAL_BACKFILL_LAG_SEC = 300n; // 5 minutes
 ponder.on("ClaimableRefresh:block", async ({ event, context }) => {
+  const wallNow = BigInt(Math.floor(Date.now() / 1000));
+  if (wallNow - event.block.timestamp > HISTORICAL_BACKFILL_LAG_SEC) return;
+
   const chainId = context.chain?.id as number;
   await refreshAllSubscriberClaimable(context, {
     chainId,


### PR DESCRIPTION
## Summary
- During historical backfill, the `ClaimableRefresh:block` handler iterates every `SubscriberClaimable` row and runs `computeClaimable` once per configured interval — but those intermediate values are never read (queries are gated on `/ready`, which is 404 until backfill completes).
- This is the dominant cost during long backfills. Estimated waste per fresh deploy / blue-green re-sync:
  - **Sepolia** (interval=7200, ~700K backfill blocks): ~100 ticks × N subscribers per tick.
  - **Base Sepolia** (interval=3600, ~3.2M backfill blocks): ~900 ticks × N subscribers per tick.
- Fix: short-circuit the handler when the indexing block's timestamp lags wall-clock by more than 5 minutes. Refreshes during live indexing run as before.